### PR TITLE
chore: vendor authored skills and add portable setup registry

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,146 @@
+# Skills & Plugins Registry
+
+Portable reference for George's Claude Code coding setup. Skill folders under this directory are vendored copies of skills authored by me. The rest is a registry of external skills and plugins I use, with install sources so this setup can be reconstructed on a fresh machine.
+
+## Skills authored by me (vendored here)
+
+| Skill | Trigger / Scope | Upstream |
+|---|---|---|
+| [`graphite-atomic/`](./graphite-atomic/) | Atomic commits + stacked PRs via `gt`. Active only in repos with `.graphite_repo_config`. | `~/.claude/skills/graphite-atomic/` |
+| [`jj-vcs-comprehensive/`](./jj-vcs-comprehensive/) | Jujutsu (jj) VCS — colocated workspaces, bookmarks, GitHub sync, conflict resolution. | `~/.claude/skills/jj-vcs-comprehensive/` |
+
+These are committed into the repo so the canonical source is versioned. To update, edit in place here and copy out to `~/.claude/skills/<name>/` (or symlink during local dev).
+
+## External skills I use
+
+Installed directly under `~/.claude/skills/` (not via a plugin). Source/install notes:
+
+| Skill | Purpose | Source |
+|---|---|---|
+| `firecrawl`, `firecrawl-scrape`, `firecrawl-search`, `firecrawl-map`, `firecrawl-crawl`, `firecrawl-agent`, `firecrawl-interact`, `firecrawl-download` | Web scraping / search / crawl via Firecrawl CLI | Firecrawl (likely `skills.sh` or Firecrawl docs) |
+| `nlm-skill` | NotebookLM CLI + MCP (`nlm`) | NotebookLM MCP package |
+| `sketch-implement-design` | Translate Sketch layers → code via Sketch MCP | Sketch MCP server |
+| `cmux-theme` | cmux terminal multiplexer | cmux.app distribution |
+| `forgecad` | ForgeCAD geometry authoring | ForgeCAD project |
+| `create-bbb` | `.bbb` brand files | External — bundled with brand tooling |
+| `openspec-conflux-init`, `openspec-archiving` | OpenSpec / Conflux (`cflx`) change proposals | OpenSpec tooling |
+| `remotion-best-practices` | Remotion video | Remotion docs |
+| `ms-office-suite` | Word / PDF / PowerPoint manipulation | Generic Office skill |
+| `sql-server-maintenance` | SQL Server DBA ops | Generic SQL Server skill |
+| `copywriting` | Marketing copy | Generic |
+| `frontend-design` | Also ships via `frontend-design@claude-plugins-official` plugin — standalone skill copy here. | anthropics plugin |
+| `find-skills` | Skill discovery/install | Anthropic built-in |
+| `graphify` | Knowledge-graph builder (`/graphify`) | External (referenced in global `CLAUDE.md`) |
+| `dg` | Dinesh vs Gilfoyle adversarial review (`/dg`) | External |
+
+> **TODO**: backfill exact install command / source URL for each row. Some likely came from `skills.sh` — if I can find the install command history, I'll pin it here.
+
+## Plugin marketplaces
+
+From `~/.claude/plugins/known_marketplaces.json`:
+
+### Mine (George-RD)
+
+| Marketplace | Source | Notes |
+|---|---|---|
+| `claude-next-level` | [`github:George-RD/claude-next-level`](https://github.com/George-RD/claude-next-level) | This repo. |
+| `reaveshq-claude-plugins` | `git:https://github.com/George-RD/reaveshq-claude-plugins.git` | Reaves HQ plugins. |
+| `mordor-forge` | `git:https://github.com/George-RD/mordor-forge.git` | ide-of-sauron et al. |
+| `mag-plugins` | [`github:George-RD/mag-plugins`](https://github.com/George-RD/mag-plugins) | MAG memory plugin. |
+| `my-claude-plugins` | `directory:~/.claude/plugins/marketplaces/my-claude-plugins` | Local-only marketplace. |
+| `my_local_plugins` | (local, referenced in `installed_plugins.json`) | Earlier alias; some overlap with `my-claude-plugins`. |
+
+### Third-party
+
+| Marketplace | Source |
+|---|---|
+| `claude-plugins-official` | [`github:anthropics/claude-plugins-official`](https://github.com/anthropics/claude-plugins-official) |
+| `axiom-marketplace` | [`github:CharlesWiltgen/Axiom`](https://github.com/CharlesWiltgen/Axiom) |
+| `supabase-agent-skills` | [`github:supabase/agent-skills`](https://github.com/supabase/agent-skills) |
+| `cli-anything` | [`github:HKUDS/CLI-Anything`](https://github.com/HKUDS/CLI-Anything) |
+| `verygoodplugins-mcp-automem` | `git:https://github.com/verygoodplugins/mcp-automem.git` |
+| `openai-codex` | `git:https://github.com/openai/codex-plugin-cc.git` |
+| `claude-code-workflows` | (see `installed_plugins.json` — used for agent-orchestration, debugging-toolkit, unit-testing, etc.) |
+
+## Installed plugins
+
+Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugin install <name>@<marketplace>`.
+
+### From `claude-next-level` (mine, this repo)
+
+- `grandslam-offer@claude-next-level` v1.0.0
+- `hundred-million-leads@claude-next-level` v1.0.0
+- `cycle@claude-next-level` v2.0.0
+- `jj-commands@claude-next-level` v1.0.0
+- `ralph-wiggum-toolkit@claude-next-level` v2.0.0
+
+### From `mordor-forge` (mine)
+
+- `ide-of-sauron@mordor-forge` v2.0.4
+
+### From `reaveshq-claude-plugins` (mine)
+
+- `brand-toolkit` v2.0.0
+- `excalidraw-generation` v1.0.0
+- `latex-handouts` v1.0.0
+- `playwright-cli` v1.0.0
+- `revealjs` v1.0.0
+- `slidev` v1.0.0
+- `frontend-harness` v1.2.0
+
+### From `mag-plugins` (mine)
+
+- `mag@mag-plugins` v0.1.1
+
+### From `my-claude-plugins` / `my_local_plugins` (local)
+
+- `arch-patterns` v1.0.1
+- `research-framework` v1.0.0
+- `fugro-investigation` v1.0.0
+- `automem-helper` v1.0.0
+
+### From `claude-plugins-official` (Anthropic)
+
+- `context7`, `frontend-design`, `feature-dev`, `code-review`, `commit-commands`
+- `pr-review-toolkit`, `playwright`, `ralph-wiggum` (deprecated in favour of ralph-wiggum-toolkit)
+- `serena`, `rust-analyzer-lsp`, `typescript-lsp`, `swift-lsp` (project-scoped)
+- `greptile`, `hookify`, `superpowers`, `code-simplifier`
+- `claude-code-setup`, `claude-md-management`, `skill-creator`
+- `supabase`, `github` (project-scoped), `security-guidance` (project-scoped)
+- `circleback`, `plugin-dev`, `coderabbit`, `linear`, `posthog` (project-scoped)
+- `huggingface-skills` (project-scoped), `fakechat`, `vercel`, `telegram`
+
+### From `claude-code-workflows`
+
+- `agent-orchestration` v1.2.0 (project-scoped)
+- `multi-platform-apps` v1.2.1
+- `error-debugging` v1.2.0, `unit-testing` v1.2.0
+- `debugging-toolkit` v1.2.0, `error-diagnostics` v1.2.0
+- `ralph-loop@claude-plugins-official` (separate project install)
+
+### From other sources
+
+- `axiom@axiom-marketplace` v3.0.3 (project-scoped, yarnling-ios)
+- `postgres-best-practices@supabase-agent-skills` (project-scoped)
+- `cli-anything@cli-anything`
+- `automem@verygoodplugins-mcp-automem` v0.13.0
+- `codex@openai-codex` v1.0.2
+
+## Rebuilding this setup on a fresh machine
+
+1. Install Claude Code CLI.
+2. Add the marketplaces listed above (`/plugin marketplace add <repo>`).
+3. Install plugins from each marketplace.
+4. Copy the vendored skills here into `~/.claude/skills/`:
+
+   ```bash
+   cp -r .claude/skills/graphite-atomic ~/.claude/skills/
+   cp -r .claude/skills/jj-vcs-comprehensive ~/.claude/skills/
+   ```
+
+5. Reinstall any standalone `~/.claude/skills/` entries from the External skills table above (most likely via `skills.sh` or their upstream docs).
+
+## Notes
+
+- `.claude/skills/` is auto-loaded by Claude Code when working in this repo, so vendored skills are live here as well as backed up.
+- Source of truth for skill authorship: the `SKILL.md` frontmatter does not reliably carry an author field — I'm using habit/setup patterns to classify. When in doubt, the "Candidates" section above is where to triage.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -143,4 +143,4 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 ## Notes
 
 - `.claude/skills/` is auto-loaded by Claude Code when working in this repo, so vendored skills are live here as well as backed up.
-- Source of truth for skill authorship: the `SKILL.md` frontmatter does not reliably carry an author field — I'm using habit/setup patterns to classify. When in doubt, the "Candidates" section above is where to triage.
+- Source of truth for skill authorship: the `SKILL.md` frontmatter does not reliably carry an author field — I'm using habit/setup patterns to classify. When in doubt, confirm authorship before vendoring.

--- a/.claude/skills/graphite-atomic/SKILL.md
+++ b/.claude/skills/graphite-atomic/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: graphite-atomic
+description: Use when the user mentions Graphite, the `gt` CLI, stacked PRs, atomic commits, or splitting a large change into reviewable pieces, OR when working in a repo that has `.graphite_repo_config` set. Guides agents to produce atomic commits (≤400 lines each) and stacked pull requests via `gt` in Graphite-initialised repos. Worktree-safe. Read references/setup.md before initialising a new project.
+---
+
+# Graphite Atomic Commits and Stacked PRs
+
+## When this skill is active
+
+Only in repositories that have been initialised with Graphite. Check before acting:
+
+```bash
+test -f "$(git rev-parse --git-common-dir)/.graphite_repo_config"
+```
+
+If that command fails or returns no output, the repo is not Graphite-initialised. Use plain `git`. Do not attempt `gt` commands. If the user wants to initialise, read `references/setup.md`.
+
+This check uses `--git-common-dir` instead of `.git/.graphite_repo_config` directly so it works correctly inside git worktrees, where `.git` is a pointer file rather than a directory.
+
+## Core rules
+
+1. **One logical unit per commit.** Target ≤250 lines added+removed. Hard cap ≤400 lines. If a single change is larger, split the logical unit. See `references/commit-sizing.md` for splitting heuristics.
+2. **One commit is one PR.** Create each commit with `gt create -am "<subject>"`. Each call adds a new branch and PR to the current stack.
+3. **Stack per agent, per worktree.** Each worktree owns its own stack. Never push commits onto another agent's branch. Sync trunk via `gt sync` at phase or wave boundaries, not mid-commit. Full protocol in `references/stack-per-agent.md`.
+4. **Prefer `gt` over `git` for branch and history operations.** Plain `git status`, `git log`, `git diff` remain fine. The substitution table is in `references/command-mapping.md`.
+5. **Conventional commit subjects.** `<type>(<scope>): <capitalised subject>`. Plain English. No em-dashes. No LLM filler phrases.
+6. **Return the Graphite PR URL** (`app.graphite.dev/github/pr/…`), not the GitHub URL, so the user can navigate the stack.
+7. **Trunk is whatever `gt trunk` reports.** Never assume `main`. Never assume `dev`. If `gt trunk` returns no value, the repo is not initialised. See the activation rule above.
+8. **Amend only for review feedback on the current PR.** `gt modify -a` updates the current branch with staged changes. For anything else, create a new branch with `gt create -am`.
+
+## Commit boundary in practice
+
+When you have changes staged, before running `git commit` or `gt create`, ask:
+
+1. Does this represent one logical unit that can be described in one conventional-commit subject?
+2. Is the diff ≤400 lines?
+3. Does the build still pass at this commit?
+
+If all three are yes, commit via `gt create -am`. If any is no, split or finish the unit first. Worked examples in `references/commit-sizing.md`.
+
+## Retro-split fallback (headless-safe path)
+
+If the current branch already holds one large squashed commit that should have been a stack, the recovery path depends on whether you are interactive or headless.
+
+**Interactive (human at the keyboard):** `gt split --by-hunk` walks through interactive staging.
+
+**Headless (agent session):** `--by-hunk` is unusable (interactive only). `gt split --by-file` works programmatically but typically over-splits, because a phase-sized commit spans many files across `src/`, tests, specs, and fixtures. Prefer this recovery path instead:
+
+```bash
+# 1. Reset to the trunk merge-base. All changes become staged.
+git reset --soft "$(git merge-base HEAD "$(gt trunk)")"
+
+# 2. Unstage everything; the changes stay in the working tree untouched.
+git reset HEAD
+
+# 3. For each logical unit, stage only its files and commit with gt create -m.
+#    Use -m, NOT -am. The -a flag re-stages all tracked modifications, which
+#    would undo the selective `git add` and collapse the split back into one commit.
+git add <files-for-unit-1>
+gt create -m "<type>(<scope>): <subject for unit 1>"
+
+git add <files-for-unit-2>
+gt create -m "<type>(<scope>): <subject for unit 2>"
+# …continue per logical unit.
+```
+
+This mirrors the forward path (commit atomically as units land) rather than rescuing a squashed commit mechanically.
+
+## Publishing the stack
+
+Once the stack is ready:
+
+```bash
+gt submit --stack --no-interactive
+```
+
+The `--no-interactive` flag skips prompts, safe in non-interactive agent sessions. Drop `--stack` to update only the current branch.
+
+After submit, return the Graphite PR URL to the user, not the GitHub URL. `gt submit` prints a Graphite URL per branch in its output (format `https://app.graphite.dev/github/pr/<owner>/<repo>/<number>/...`). Extract the URL for the stack tip (or the full list if the user wants to navigate the stack) from the command's stdout; do not fabricate a URL from the PR number and GitHub repo path.
+
+## Conflicts
+
+- Auto-resolve where safe: whitespace, formatting, non-overlapping additions, and imports *in languages where import order is semantically inert*.
+- Escalate: same region edited differently, delete-vs-modify, semantic conflicts, test-expectation divergence, lockfile conflicts.
+
+Full policy in `references/conflict-resolution.md`.
+
+## Setting up a new project
+
+Read `references/setup.md`. It covers installing `gt`, running `gt init --trunk <trunk>` with a version gate, `gt auth` via browser OAuth (credential-safe), anchoring the skill directive in the project's `CLAUDE.md`, the optional protective PreToolUse hook (fail-closed pattern), and consumer clauses for cflx `apply_prompt` and sauron waves.
+
+## Quick reference
+
+| Intent | Command |
+|---|---|
+| Start new branch + commit | `gt create -am "<subject>"` |
+| Amend the current PR | `gt modify -a` |
+| Add another commit on the same branch | `gt modify -c -am "<subject>"` |
+| Publish the whole stack | `gt submit --stack --no-interactive` |
+| Pull trunk and restack | `gt sync` |
+| Show the stack | `gt log` |
+| Navigate up/down | `gt up` / `gt down` |
+| Split an existing commit (headless) | See "Retro-split fallback" above |
+
+Full table with notes in `references/command-mapping.md`.

--- a/.claude/skills/graphite-atomic/references/command-mapping.md
+++ b/.claude/skills/graphite-atomic/references/command-mapping.md
@@ -20,6 +20,7 @@ Prefer `gt` for any command that affects branches or commit history in a Graphit
 | Move the current branch onto a new base | `gt move --onto <target>` | For reorganising stacks. |
 | Re-apply the stack on an updated base | `gt restack` | Fired automatically after `gt sync`; run manually after a conflict resolution. |
 | Continue after resolving a conflict | `gt continue` | Resumes `gt restack` once you've resolved and staged the fix. |
+| Abort an in-flight restack/rebase | `gt abort` | Standalone command — there is no `--abort` flag on `gt restack`. Reverts the working copy to the pre-command state. |
 | Trunk name | `gt trunk` | Returns the configured trunk; never assume `main`. |
 
 ## Raw git that is always safe

--- a/.claude/skills/graphite-atomic/references/command-mapping.md
+++ b/.claude/skills/graphite-atomic/references/command-mapping.md
@@ -1,0 +1,55 @@
+# git to gt Command Mapping
+
+Prefer `gt` for any command that affects branches or commit history in a Graphite-initialised repo. Plain git reads remain fine.
+
+## Main substitutions
+
+| Intent | gt command | Notes |
+|---|---|---|
+| New branch + first commit | `gt create -am "<subject>"` | Creates a branch, stages all tracked changes, commits. Each call adds one PR to the stack. |
+| Amend the current PR | `gt modify -a` | Use for review feedback on the current branch. Stages and amends in one step. |
+| Add another commit on the same branch | `gt modify -c -am "<subject>"` | Keeps you on the current branch, adds a new commit. The PR gets a new commit, not a new branch. |
+| Publish the full stack | `gt submit --stack --no-interactive` | `--no-interactive` skips prompts, safe in agent sessions. |
+| Publish only the current branch | `gt submit --no-interactive` | Single-PR submit. |
+| Pull trunk and restack | `gt sync` | Run at phase or wave boundaries, not mid-commit. |
+| Navigate up the stack | `gt up` | Toward the tip. |
+| Navigate down the stack | `gt down` | Toward trunk. |
+| Show stack state | `gt log` | Shows every branch in the current stack with status. |
+| Delete a branch | `gt delete <branch>` | Handles stack restacking cleanly. |
+| Split one commit into a stack | `gt split` | Variants: `--by-commit` (per-commit, programmatic), `--by-file` (per-file, programmatic), `--by-hunk` (**interactive only; not usable in headless agent sessions**. See SKILL.md "Retro-split fallback" for the headless path). |
+| Move the current branch onto a new base | `gt move --onto <target>` | For reorganising stacks. |
+| Re-apply the stack on an updated base | `gt restack` | Fired automatically after `gt sync`; run manually after a conflict resolution. |
+| Continue after resolving a conflict | `gt continue` | Resumes `gt restack` once you've resolved and staged the fix. |
+| Trunk name | `gt trunk` | Returns the configured trunk; never assume `main`. |
+
+## Raw git that is always safe
+
+- `git status`
+- `git log` / `git log --oneline`
+- `git diff` / `git diff --staged`
+- `git show <hash>`
+- `git stash` / `git stash pop` (for in-flight WIP; `gt` does not wrap this)
+- `git add` / `git add -p` / `git reset` (staging operations; `gt create -am` and `gt modify -a` consume the staging area)
+- `git blame`, `git grep`, `git rev-parse`, `git worktree list`
+
+These are read-only or affect only the staging area, so they do not break `gt`'s model of the stack.
+
+## Raw git that is a red flag
+
+If you catch yourself running any of these in a Graphite repo, stop and use the `gt` equivalent:
+
+| You wrote | Use instead |
+|---|---|
+| `git commit -m` | `gt create -am` (new branch) or `gt modify -c -am` (same branch) |
+| `git commit --amend` | `gt modify -a` |
+| `git push` | `gt submit` |
+| `git push --force` | `gt submit` (gt handles force-push semantics per-branch; avoid raw force-push) |
+| `git checkout -b` | `gt create` |
+| `git rebase -i` | `gt modify` plus `gt split` |
+| `git rebase <base>` | `gt sync` or `gt restack` |
+| `git branch -D` | `gt delete` |
+| `git merge <branch>` | Do not run `git merge` manually. Merges driven by `gt` operations (sync, restack) and the Graphite merge queue are fine. Manual local merges confuse the stack model. |
+
+## Why `gt` instead of raw git
+
+`gt` maintains metadata about branch-to-branch relationships in `.git/.graphite_repo_config`. Raw git commands that create or delete branches can silently break that metadata, which shows up later as restack errors or mis-ordered stacks. Every `gt` alternative above preserves the metadata.

--- a/.claude/skills/graphite-atomic/references/command-mapping.md
+++ b/.claude/skills/graphite-atomic/references/command-mapping.md
@@ -6,7 +6,7 @@ Prefer `gt` for any command that affects branches or commit history in a Graphit
 
 | Intent | gt command | Notes |
 |---|---|---|
-| New branch + first commit | `gt create -am "<subject>"` | Creates a branch, stages all tracked changes, commits. Each call adds one PR to the stack. |
+| New branch + first commit | `gt create -am "<subject>"` | Creates a branch, stages all unstaged changes (including untracked files — `-a`/`--all`), commits. Use `-um` instead for tracked-only semantics. Each call adds one PR to the stack. |
 | Amend the current PR | `gt modify -a` | Use for review feedback on the current branch. Stages and amends in one step. |
 | Add another commit on the same branch | `gt modify -c -am "<subject>"` | Keeps you on the current branch, adds a new commit. The PR gets a new commit, not a new branch. |
 | Publish the full stack | `gt submit --stack --no-interactive` | `--no-interactive` skips prompts, safe in agent sessions. |

--- a/.claude/skills/graphite-atomic/references/commit-sizing.md
+++ b/.claude/skills/graphite-atomic/references/commit-sizing.md
@@ -1,0 +1,110 @@
+# Commit Sizing: The ≤400 Line Rule
+
+## Why the limit exists
+
+Reviewers have a finite cognitive budget. Above roughly 400 lines per PR, review quality degrades sharply for both humans and AI review tools.
+
+- Graphite's own guidance on AI reviews: review quality drops above ~400 lines.
+- Jellyfish telemetry after teams enabled AI review: average PR shrank 82% from ~1480 lines to ~270 lines.
+- A 5000-line squashed commit is effectively invisible to any reviewer.
+
+Keep commits small so reviewers can actually read them.
+
+## The rule
+
+- **Target**: ≤250 lines added+removed
+- **Hard cap**: ≤400 lines
+- **Exception**: pure-mechanical changes (generated code, bulk renames, lockfile regeneration) may exceed the cap, tagged with a `chore:` prefix and a short note in the PR body explaining why it is mechanical.
+
+## What "one logical unit" means
+
+A commit you can describe in one conventional-commit subject, that reverts cleanly, and that leaves the build green. Common patterns:
+
+- A single module or file added with its direct tests
+- A single function or type introduced, wired to one call site
+- A single refactor step (extract, rename, move) that keeps tests passing
+- A single bug fix with its regression test
+- A single config or dependency addition
+
+## Splitting heuristics
+
+When a piece of work naturally exceeds 400 lines, split by the first applicable rule:
+
+1. **Interface before implementation.** Commit N introduces the trait, type, or signature. Commit N+1 implements it.
+2. **Scaffolding before behaviour.** Commit N adds an empty module with types and placeholder functions. Commit N+1 fills in the logic.
+3. **Tests before wiring.** Commit N adds tests marked `#[ignore]` or equivalent. Commit N+1 implements and removes the `#[ignore]`.
+4. **Refactor before change.** Commit N performs a behaviour-preserving refactor. Commit N+1 changes behaviour.
+5. **Mechanical before semantic.** Commit N renames, moves, or regenerates. Commit N+1 changes meaning.
+
+If none of the five apply, the work may genuinely be indivisible, in which case annotate the oversize commit with the `chore:` exception and a note.
+
+## What not to split
+
+- A logical unit into arbitrary hunks just to hit the 250-line target. Sub-400 is enough. Sub-250 is aspirational.
+- A test away from the code it tests. They land together.
+- A rename across 50 files. That is mechanical; keep it as one `chore:` commit.
+- A lockfile update. Same commit as the dependency change that caused it.
+
+## Worked examples
+
+### Example 1: feature split (LSP hover)
+
+Feature: "add LSP hover that shows node metadata".
+
+Single squashed form: ~510 lines, over the cap.
+
+Split into four commits:
+
+1. `feat(lsp): add hover-handler scaffolding`: ~80 lines (trait, empty handler, registration)
+2. `feat(lsp): resolve node ID from cursor position`: ~180 lines (position-to-node lookup + tests)
+3. `feat(lsp): format hover content from node metadata`: ~200 lines (formatter + tests)
+4. `feat(lsp): wire hover into LSP server`: ~50 lines (integration)
+
+Each commit reverts cleanly. Each builds. Each is reviewable on its own.
+
+### Example 2: test-first pre-phase
+
+Feature phase preceded by a test-first pre-phase (each test is a single logical unit).
+
+Pre-phase (7 ignored tests, ~50–150 lines each):
+
+1. `test(phase-10): add LSP workspace-membership test (ignored)`
+2. `test(phase-10): add LSP diagnostic parity test (ignored)`
+3. `test(phase-10): add LSP hover test (ignored)`
+4. …continue per test
+
+Feature phase (removes `#[ignore]` and implements, one test at a time):
+
+1. `feat(phase-10): implement LSP workspace-membership, un-ignore test`
+2. `feat(phase-10): implement LSP diagnostic parity, un-ignore test`
+3. …continue per test
+
+### Example 3: a refactor phase
+
+Split of a 1200-line `god-module.rs` into five submodules.
+
+Squashed form would be ~1300 lines. Split:
+
+1. `refactor(god-module): extract parse submodule` (~300)
+2. `refactor(god-module): extract apply submodule` (~300)
+3. `refactor(god-module): extract validate submodule` (~250)
+4. `refactor(god-module): extract helpers submodule` (~200)
+5. `refactor(god-module): relocate mod tests to new layout` (~250)
+
+Each commit keeps tests green. Each is reviewable on its own.
+
+## Edge case: large test fixtures and generated content
+
+When a single commit includes bulky generated or fixture content, count only non-generated lines against the 400-line limit. Paths that count as fixtures / generated (reviewer-skippable):
+
+- `**/fixtures/**`, `**/testdata/**`, `**/__fixtures__/**`
+- `**/*.snap`, `**/*.golden`, `**/*.snapshot`
+- Generated protobuf, graphql, OpenAPI outputs (`**/*.pb.go`, `**/generated/**`)
+- Vendored dependency files (`vendor/**`, `node_modules/**`)
+- Lockfiles (`Cargo.lock`, `package-lock.json`, `poetry.lock`, `yarn.lock`)
+
+Note the fixture nature in the PR body so the reviewer can focus on the meaningful diff. When the line count is borderline, err on the side of splitting: a smaller PR is always cheaper to review than a larger one with "ignore the fixture" caveats.
+
+## Edge case: unavoidably-large atomic change
+
+Some changes truly cannot be split: a `Cargo.lock` update spanning 1000 lines, a generated protobuf file, a `cargo fmt` pass that touches 40 files. Tag with `chore:` and note in the PR body that review can focus on meta rather than line-by-line diff.

--- a/.claude/skills/graphite-atomic/references/conflict-resolution.md
+++ b/.claude/skills/graphite-atomic/references/conflict-resolution.md
@@ -28,7 +28,7 @@ Pause and ask the orchestrator (or the user) before resolving any of:
 | Trunk moved; apply stack on new trunk | `gt sync` |
 | Re-apply stack after any base change | `gt restack` |
 | Conflict during restack; resolve then continue | resolve, `git add` the fix, `gt continue` |
-| Abort an in-flight restack | `gt restack --abort` |
+| Abort an in-flight restack | `gt abort` |
 
 ## After resolution
 

--- a/.claude/skills/graphite-atomic/references/conflict-resolution.md
+++ b/.claude/skills/graphite-atomic/references/conflict-resolution.md
@@ -1,0 +1,43 @@
+# Conflict Resolution Policy
+
+## Auto-resolve without asking
+
+Apply a mechanical resolution and continue when the conflict is:
+
+- Reordered or added imports **in languages where import order is semantically inert** (JavaScript, TypeScript, Go, most Rust). Skip auto-resolve for Python (`__init__` side effects), Ruby (`require` side effects), or any language where imports carry load-time behaviour.
+- Whitespace-only differences
+- Non-overlapping additions in the same file (both sides added different hunks at different locations)
+- Formatting changes (reformat on save, auto-formatter drift)
+
+After any auto-resolve, run the build or test gate before proceeding. If the gate fails, revert the auto-resolve and escalate.
+
+## Escalate before acting
+
+Pause and ask the orchestrator (or the user) before resolving any of:
+
+- **Same region, different edits.** Both sides modified lines N..M in incompatible ways.
+- **Delete vs modify.** One side deleted a file or block, the other modified it.
+- **Semantic conflicts.** Both sides edited different files, but the combination breaks an invariant. E.g., one side changed a function signature, the other added a new caller using the old signature.
+- **Test expectation divergence.** Both sides changed the expected output of the same test.
+- **Lockfile conflicts.** Regenerate the lockfile rather than line-merging it, and note which dependency versions were chosen in the PR body.
+
+## Recovery commands
+
+| Situation | Command |
+|---|---|
+| Trunk moved; apply stack on new trunk | `gt sync` |
+| Re-apply stack after any base change | `gt restack` |
+| Conflict during restack; resolve then continue | resolve, `git add` the fix, `gt continue` |
+| Abort an in-flight restack | `gt restack --abort` |
+
+## After resolution
+
+- Run the test suite before submitting.
+- Update the affected PR's description to note the conflict was resolved and what was chosen, so reviewers see the decision context.
+- If the resolution changed behaviour, add a separate commit via `gt create -am "fix: reconcile conflict from <other-branch>"` rather than hiding the change inside the restack.
+
+## What to avoid
+
+- **Force-pushing to clear a conflict.** Use `gt` operations; they handle force-push semantics per-branch where needed.
+- **Silently dropping one side.** If you cannot represent both intents, escalate. Do not guess.
+- **Merging locally to skip the stack.** `git merge` of another branch into your stack confuses `gt`'s metadata. Use `gt sync` or `gt restack`.

--- a/.claude/skills/graphite-atomic/references/setup.md
+++ b/.claude/skills/graphite-atomic/references/setup.md
@@ -130,17 +130,17 @@ raw=$(printf '%s' "$input" | jq -r '.tool_input.command // empty') || fail_close
 #   -C <dir> form:   `git -C /tmp commit`
 GIT_PREFIX='(^|[[:space:]]|/)git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?'
 
-if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}(commit|push|rebase|merge)\b"; then
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}(commit|push|rebase|merge)([[:space:]]|$)"; then
   echo '{"decision":"block","reason":"Use gt (create/modify/submit/sync) per graphite-atomic skill. Manual git merge confuses the stack — let gt sync/restack or the merge queue handle it. Plain git reads like git status and git log are fine."}'
   exit 0
 fi
 
-if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}branch[[:space:]]+(-D|-d|--delete)\b"; then
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}branch[[:space:]]+(-D|-d|--delete)([[:space:]]|$)"; then
   echo '{"decision":"block","reason":"Use gt delete per graphite-atomic skill."}'
   exit 0
 fi
 
-if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}checkout[[:space:]]+(-b|-B)\b"; then
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}checkout[[:space:]]+(-b|-B)([[:space:]]|$)"; then
   echo '{"decision":"block","reason":"Use gt create per graphite-atomic skill."}'
   exit 0
 fi

--- a/.claude/skills/graphite-atomic/references/setup.md
+++ b/.claude/skills/graphite-atomic/references/setup.md
@@ -1,0 +1,215 @@
+# Setting Up graphite-atomic in a Project
+
+Run through this once per repository. Keep the skill itself slim; most project-specific setup lives here so the skill body stays small in context.
+
+## 1. Install the Graphite CLI
+
+macOS via Homebrew:
+
+```bash
+brew install withgraphite/tap/graphite
+```
+
+Other platforms: see <https://graphite.com/docs/install-the-cli>.
+
+Verify and gate on the MCP-support minimum (≥ 1.6.7). The awk-based comparison below avoids `sort -V -C` portability gaps between GNU and BSD sort (macOS ships BSD by default):
+
+```bash
+GT_VERSION=$(gt --version 2>/dev/null | awk '{print $NF}')
+test -n "$GT_VERSION" || { echo "gt not installed"; exit 1; }
+awk -v cur="$GT_VERSION" -v min="1.6.7" 'BEGIN {
+  split(cur, c, "."); split(min, m, ".");
+  for (i = 1; i <= 3; i++) {
+    if ((c[i]+0) > (m[i]+0)) exit 0;
+    if ((c[i]+0) < (m[i]+0)) exit 1;
+  }
+  exit 0;
+}' || { echo "gt $GT_VERSION is older than 1.6.7"; exit 1; }
+```
+
+## 2. Initialise in the repo
+
+From the repo root (not a worktree):
+
+```bash
+gt init --trunk <trunk-branch>
+```
+
+Use the actual trunk for the project. For CAIRN that is `dev`, not `main`. Confirm:
+
+```bash
+gt trunk
+```
+
+This creates `.graphite_repo_config` inside the git common dir. In a non-worktree checkout it resolves to the regular `.git/.graphite_repo_config`. In a worktree it lives in the main repo's `.git/`, not in the worktree's `.git` pointer file. The activation check always uses `$(git rev-parse --git-common-dir)/.graphite_repo_config` for this reason.
+
+## 3. Authenticate
+
+```bash
+gt auth
+```
+
+Opens a browser for OAuth. Required for `gt submit`. This needs the human's hands. An agent cannot complete browser OAuth on the user's behalf.
+
+If the browser flow fails, reset and retry:
+
+```bash
+gt auth --reset
+gt auth
+```
+
+**Do not** fall back to pasting a long-lived Personal Access Token via `gt config set github_token`. Plaintext PATs in `gt`'s config file leak via backups, cloud sync, and shell history. If OAuth is genuinely blocked (air-gapped dev, CI runner):
+
+- Prefer a **fine-grained personal access token** scoped to the single repository you are working in, rather than a classic PAT. Fine-grained PATs let you pick the exact repo and the minimum actions (commit read/write, PR read/write).
+- If you must use a classic PAT, avoid the `repo` scope. `repo` grants full read/write across *every* private repository the user can access. Use `public_repo` for public repos; only escalate to `repo` when you genuinely need write access to a specific private repo and understand the blast radius.
+- Store the token in the OS keychain (macOS Keychain, `pass`, `gh auth token`), not `gt config`.
+- Rotate after the session.
+
+## 4. Anchor the rules in CLAUDE.md
+
+Append to the project's `CLAUDE.md` (create if missing):
+
+```markdown
+## Graphite stacking
+
+This project uses Graphite for atomic commits and stacked PRs.
+- Use `gt create -am "<subject>"` to start a new branch plus commit
+- Target ≤250 lines, hard cap ≤400 lines per commit
+- One logical unit per commit. One commit per PR.
+- Prefer `gt` over `git` for anything that affects branches or history
+- Full rules live in the `graphite-atomic` skill
+
+Trunk is `<trunk-branch>`. Publish the stack via `gt submit --stack --no-interactive`.
+```
+
+Replace `<trunk-branch>` with the actual trunk. This anchors the skill's rules in persistent context so the agent sees them at every session start, not only when the skill triggers.
+
+## 5. Optional: protective PreToolUse hook (fail-closed)
+
+If agents in this project reach for `git commit` / `git push` / `git checkout -b` when they should be using `gt`, add a PreToolUse hook. The pattern below **fails closed**: if the hook cannot parse its input, it blocks the tool call rather than allowing it through.
+
+Create `.claude/hooks/graphite-pretool.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -u
+
+# This hook is a heuristic defence-in-depth, not a sandbox. It catches common
+# drift (plain `git commit`, absolute-path git, env-prefixed git, `git -C <dir>`
+# form) but a command that actively evades it (shell eval, command substitution,
+# `--git-dir=` option, exotic whitespace) will still succeed. Treat this as a
+# seatbelt; the skill ruleset is the primary discipline.
+
+fail_closed() {
+  echo '{"decision":"block","reason":"graphite-atomic hook could not verify the command. Failing closed. Fix the hook or use gt (create/modify/submit/delete)."}'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || fail_closed
+
+input=$(cat)
+raw=$(printf '%s' "$input" | jq -r '.tool_input.command // empty') || fail_closed
+[ -n "$raw" ] || { echo '{"decision":"allow"}'; exit 0; }
+
+# Match a git invocation regardless of:
+#   bare git:        `git commit`
+#   leading space:   `  git commit`
+#   absolute path:   `/usr/bin/git commit`
+#   env prefix:      `env X=y git commit`
+#   -C <dir> form:   `git -C /tmp commit`
+GIT_PREFIX='(^|[[:space:]]|/)git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?'
+
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}(commit|push|rebase)\b"; then
+  echo '{"decision":"block","reason":"Use gt (create/modify/submit) per graphite-atomic skill. Plain git reads like git status and git log are fine."}'
+  exit 0
+fi
+
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}branch[[:space:]]+(-D|-d|--delete)\b"; then
+  echo '{"decision":"block","reason":"Use gt delete per graphite-atomic skill."}'
+  exit 0
+fi
+
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}checkout[[:space:]]+(-b|-B)\b"; then
+  echo '{"decision":"block","reason":"Use gt create per graphite-atomic skill."}'
+  exit 0
+fi
+
+echo '{"decision":"allow"}'
+```
+
+Make it executable:
+
+```bash
+chmod +x .claude/hooks/graphite-pretool.sh
+```
+
+Register in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": ".claude/hooks/graphite-pretool.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The hook is optional. The skill alone is usually sufficient. Add it only if you observe `git` drift in practice.
+
+## 6. If using cflx: apply_prompt clause
+
+Add to `.cflx.jsonc` under the `apply_prompt` key. Append this paragraph to the existing prompt. **Substitute placeholders** (`<phase-id>`, `<trunk-branch>`) at configuration time with literals for the project (e.g., `phase-8` for phase-8-summariser):
+
+```
+You have access to the graphite-atomic skill. Each time you complete a logical unit of work under the 400-line cap, create a new branch and commit:
+
+    gt create -am "<type>(<phase-id>): <subject>"
+
+Substitute <phase-id> with this apply's phase slug when writing each subject
+(for phase-8-summariser, use `phase-8`). At the end of apply, publish the
+stack with `gt submit --stack --no-interactive`. Prefer `gt` over `git`
+for branch and commit operations. Read the skill's SKILL.md for the full ruleset.
+```
+
+The cflx consumer stays thin. It says "use the skill"; the skill says how.
+
+## 7. If using sauron or another phase runner
+
+Equivalent clause wherever that runner's agent instructions live. For sauron waves, use the wave slug in place of a phase id (e.g., `feat(wave-3): …`). Same skill, same rules, different consumer.
+
+## 8. Verify activation
+
+From the repo root or any worktree:
+
+```bash
+test -f "$(git rev-parse --git-common-dir)/.graphite_repo_config" && echo OK
+```
+
+Prints `OK` when activation will fire.
+
+## 9. First test commit
+
+Make a trivial change, then:
+
+```bash
+gt create -am "chore: initial graphite test"
+gt log
+```
+
+If the branch appears in `gt log` with the expected trunk base, setup is complete.
+
+## Troubleshooting
+
+- **`gt: command not found`**: install the CLI (step 1).
+- **`gt init` fails with "already initialised"**: `.graphite_repo_config` exists; skip to step 3.
+- **Skill activation check fails inside a worktree**: the check uses `git rev-parse --git-common-dir` to resolve the shared `.git` path. Verify the command runs inside the worktree.
+- **OAuth fails**: `gt auth --reset && gt auth`. If that still fails, see the PAT warning in step 3 before considering token auth.
+- **Pre-commit hook fails during `gt create`**: `gt create` runs `git commit` internally. The pre-commit hook fires normally. Fix the underlying failure (formatter, linter, type check) rather than bypassing.
+- **EPERM on `~/.local/share/graphite/`**: `gt` uses this path for state. Fix via `chmod -R u+rw ~/.local/share/graphite/` or remove the directory and let `gt` recreate it.
+- **Hook blocks a legitimate command**: the PreToolUse hook errs on the side of blocking. If you need to run a raw git command once, temporarily disable the hook by renaming `graphite-pretool.sh` to `graphite-pretool.sh.off`, run the command, then rename back.

--- a/.claude/skills/graphite-atomic/references/setup.md
+++ b/.claude/skills/graphite-atomic/references/setup.md
@@ -45,11 +45,21 @@ This creates `.graphite_repo_config` inside the git common dir. In a non-worktre
 
 ## 3. Authenticate
 
+Before asking the user to run `gt auth`, the agent should probe whether auth already exists. Graphite does not expose a direct `gt auth status` command, but from a branch with commits on top of trunk the following reaches the Graphite API and fails with an auth error when unauthed:
+
+```bash
+gt submit --dry-run --no-interactive
+```
+
+Caveat: on a clean trunk with nothing to submit, `gt submit --dry-run` short-circuits with "Nothing to submit!" and exits 0 without hitting the API. It cannot confirm auth in that state. If there is no stack to probe, ask the user directly ("have you run `gt auth` in a recent session?") rather than having them re-auth blindly.
+
+When auth is genuinely missing:
+
 ```bash
 gt auth
 ```
 
-Opens a browser for OAuth. Required for `gt submit`. This needs the human's hands. An agent cannot complete browser OAuth on the user's behalf.
+Opens a browser for OAuth. Required for `gt submit`. This needs the human's hands — an agent cannot complete browser OAuth on the user's behalf.
 
 If the browser flow fails, reset and retry:
 
@@ -120,8 +130,8 @@ raw=$(printf '%s' "$input" | jq -r '.tool_input.command // empty') || fail_close
 #   -C <dir> form:   `git -C /tmp commit`
 GIT_PREFIX='(^|[[:space:]]|/)git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?'
 
-if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}(commit|push|rebase)\b"; then
-  echo '{"decision":"block","reason":"Use gt (create/modify/submit) per graphite-atomic skill. Plain git reads like git status and git log are fine."}'
+if printf '%s' "$raw" | grep -Eq "${GIT_PREFIX}(commit|push|rebase|merge)\b"; then
+  echo '{"decision":"block","reason":"Use gt (create/modify/submit/sync) per graphite-atomic skill. Manual git merge confuses the stack — let gt sync/restack or the merge queue handle it. Plain git reads like git status and git log are fine."}'
   exit 0
 fi
 
@@ -167,7 +177,7 @@ The hook is optional. The skill alone is usually sufficient. Add it only if you 
 
 Add to `.cflx.jsonc` under the `apply_prompt` key. Append this paragraph to the existing prompt. **Substitute placeholders** (`<phase-id>`, `<trunk-branch>`) at configuration time with literals for the project (e.g., `phase-8` for phase-8-summariser):
 
-```
+```text
 You have access to the graphite-atomic skill. Each time you complete a logical unit of work under the 400-line cap, create a new branch and commit:
 
     gt create -am "<type>(<phase-id>): <subject>"

--- a/.claude/skills/graphite-atomic/references/setup.md
+++ b/.claude/skills/graphite-atomic/references/setup.md
@@ -77,6 +77,7 @@ This project uses Graphite for atomic commits and stacked PRs.
 - Target ≤250 lines, hard cap ≤400 lines per commit
 - One logical unit per commit. One commit per PR.
 - Prefer `gt` over `git` for anything that affects branches or history
+- Do not run `git merge` manually — let `gt sync` / `gt restack` or the Graphite merge queue handle merges; manual merges confuse the stack model
 - Full rules live in the `graphite-atomic` skill
 
 Trunk is `<trunk-branch>`. Publish the stack via `gt submit --stack --no-interactive`.

--- a/.claude/skills/graphite-atomic/references/stack-per-agent.md
+++ b/.claude/skills/graphite-atomic/references/stack-per-agent.md
@@ -1,0 +1,48 @@
+# Stack Per Agent: Multi-Worktree Collaboration
+
+## The model
+
+Each agent operates in its own git worktree and owns its own stack. Agents coordinate through trunk, never by pushing onto each other's branches.
+
+## Rules
+
+1. **One stack per worktree.** When an agent starts work in a worktree, it creates one stack there and grows it with `gt create -am`. It never interleaves branches from another agent's stack into its own.
+2. **Trunk is the meeting point.** When agent A's stack merges to trunk, agent B pulls it in via `gt sync` in its worktree. Cross-agent changes travel only through trunk.
+3. **`gt sync` runs per worktree.** Graphite state is worktree-local. Syncing in one worktree does not sync another. Run `gt sync` at phase or wave boundaries, not mid-commit.
+4. **Never push to another agent's branch.** If agent B needs something from agent A's unmerged stack, wait for A's stack to merge, then `gt sync` to pick it up. Do not force-push or amend A's branch from B's worktree.
+5. **Branch naming carries owner.** Prefix branches with a consumer-specific identifier to prevent accidental overwrites and make `gt log` readable. Examples by consumer:
+   - cflx phases use the phase slug: `phase-8/summariser-scaffold`
+   - sauron waves use the wave slug: `wave-3/auth-refactor`
+   - freeform work uses a task identifier: `bug-123/fix-deadlock`
+   - solo single-worktree work may omit the prefix: `summariser-scaffold`
+
+## When stacks collide at trunk
+
+Two agents merge overlapping work. Possible outcomes:
+
+- **Whichever merges first wins.** The second agent's `gt sync` reveals the conflict.
+- **Resolve in the losing agent's worktree** via `gt restack`. Never resolve by force-pushing the merged agent's work.
+- **Semantic conflict** (both touched the same API in incompatible ways): pause and escalate to the human orchestrator. This is not a `gt` problem; it is a coordination problem.
+
+## Worktree gotchas
+
+These come from Graphite's own worktree support documentation.
+
+- `gt sync` or `gt get` may update the local trunk even if trunk is checked out in another worktree. This is the one documented cross-worktree side effect. Expect it rather than fighting it.
+- `gt modify --into <branch>` refuses to operate on a branch currently checked out in another worktree. Finish the change in the owner worktree.
+- `gt undo` history is per-worktree; undoing in worktree A does not undo in worktree B.
+- Never operate the same stack from two worktrees simultaneously. If `git worktree list` shows the same branch checked out in two worktrees, reconcile by switching one worktree to a different branch (`cd <other-worktree> && git checkout <other-branch-or-trunk>`), then resume work in the remaining worktree. Do not continue committing until only one worktree holds the target branch.
+
+## Single-agent today, ready for multi-agent tomorrow
+
+This skill treats single-agent work as the one-worktree case of the multi-agent model. No rule here creates overhead when there is only one agent. When a second agent joins, the protocol is already in place. No redesign required.
+
+## Checklist before submitting a stack
+
+Before running `gt submit --stack --no-interactive`:
+
+1. `gt log` shows the expected branch sequence rooted on the correct trunk.
+2. No branch in the stack is also checked out in a different worktree.
+3. `gt sync` is up to date (trunk has not moved under you during the session).
+4. Each branch in the stack passes its independent build or test gate.
+5. No branch has a commit over the 400-line hard cap without a `chore:` exception note.

--- a/.claude/skills/jj-vcs-comprehensive/SKILL.md
+++ b/.claude/skills/jj-vcs-comprehensive/SKILL.md
@@ -190,4 +190,4 @@ jj git colocation enable   # Shared working copy
 - **Not using `--colocate`**: Required for Git tool compatibility and GitHub workflows
 - **Expecting `git pull` equivalent**: Use `jj git fetch` followed by `jj rebase -b branch -d main@origin`
 - **Creating commits without descriptions**: Use `jj describe -m "message"` to set commit messages
-- **Mixing `new` and `commit`**: `jj new` finalizes current work, `jj commit` is for colocated Git sync
+- **Mixing `new` and `commit`**: `jj new` starts a new empty change on top; `jj commit` is shorthand for `jj describe` + `jj new` — it finalizes the current change with a message and starts a new one. Neither is a Git-sync command; use `jj git fetch`/`jj git push` for that.

--- a/.claude/skills/jj-vcs-comprehensive/SKILL.md
+++ b/.claude/skills/jj-vcs-comprehensive/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: jj-vcs-comprehensive
+description: Complete Jujutsu (jj) version control system for Git replacement. Use when migrating from Git, setting up colocated workspaces, managing commits without staging, working with bookmarks/branches, syncing with GitHub/remotes, resolving conflicts, or any jj command operations.
+---
+
+# Jujutsu (JJ) Version Control
+
+Complete Git replacement with automatic commit tracking and simplified workflows.
+
+## When to Apply
+
+- Migrating from Git to jj while maintaining GitHub sync
+- Setting up colocated Git/jj workspaces for tool compatibility
+- Managing commits without staging area complexity
+- Working with bookmarks (branches) and remote synchronization
+- Resolving merge conflicts as first-class objects
+
+## Critical Rules
+
+**Colocated Workspaces**: Always use `--colocate` for Git tool compatibility
+
+```bash
+# WRONG - Creates separate .jj directory
+jj git init myproject
+
+# RIGHT - Shared working copy with Git
+jj git init --colocate myproject
+jj git clone --colocate https://github.com/user/repo
+```
+
+**Working Copy as Commit**: Changes automatically tracked without staging
+
+```bash
+# WRONG - No staging area exists
+git add file.rs
+git commit -m "message"
+
+# RIGHT - Describe current commit, changes auto-tracked
+echo "code" > file.rs
+jj describe -m "Add feature"
+jj new  # Finalize and start new commit
+```
+
+**Bookmarks vs Branches**: Use `bookmark` commands for Git branch equivalents
+
+```bash
+# WRONG - No branch command
+jj branch create feature
+
+# RIGHT - Bookmarks are jj's branch concept
+jj bookmark create feature-auth
+jj bookmark track main --remote origin
+```
+
+## Key Patterns
+
+### Repository Setup
+
+```bash
+# Clone with GitHub sync capability
+jj git clone --colocate https://github.com/user/repo
+cd repo
+
+# Convert existing Git repo
+cd existing-git-repo
+jj git init --colocate
+
+# Check colocation status
+jj git colocation status
+```
+
+### Daily Workflow
+
+```bash
+# Check status (no staging area)
+jj status
+jj diff
+
+# Set commit message for current work
+jj describe -m "Implement authentication"
+
+# View history with graph
+jj log
+jj log -r 'main::@'  # Between main and working copy
+
+# Finalize current work, start new commit
+jj new
+
+# Create commits on specific revisions
+jj new main
+jj new -r "trunk()"
+```
+
+### Bookmark Management
+
+```bash
+# Create and track bookmarks
+jj bookmark create feature-branch
+jj bookmark create ui-update -r <commit-id>
+jj bookmark track main --remote origin
+
+# List and manage
+jj bookmark list --all-remotes
+jj bookmark move feature-branch --to @
+jj bookmark delete old-feature
+jj bookmark rename old-name new-name
+```
+
+### Remote Synchronization
+
+```bash
+# Add remotes
+jj git remote add origin https://github.com/user/repo.git
+jj git remote list
+
+# Fetch and push
+jj git fetch
+jj git fetch --remote upstream
+jj git push --bookmark feature-branch --allow-new
+jj git push --all
+
+# Sync workflow (no direct pull equivalent)
+jj git fetch
+jj rebase -b my-feature -d main@origin
+jj git push --bookmark my-feature
+```
+
+### Conflict Resolution
+
+```bash
+# Conflicts are first-class objects
+jj new main feature-branch  # May create conflict
+
+# View conflicted files
+jj status
+jj log -r 'conflict()'
+
+# Resolve interactively
+jj resolve
+jj resolve src/file.rs
+
+# Manual resolution workflow
+jj new conflicted-commit  # Work on top of conflict
+# Edit files manually
+jj squash  # Move resolution into conflicted commit
+```
+
+### Advanced Operations
+
+```bash
+# Rebase operations
+jj rebase -s source-commit -d destination-commit
+jj rebase -b bookmark-name -d main
+
+# Split and squash (replaces Git staging)
+jj split file1.rs file2.rs  # Interactive split
+jj squash file3.rs  # Move to parent commit
+jj squash -i  # Interactive selection
+
+# Edit historical commits
+jj edit <commit-id>  # Change working copy to that commit
+
+# Complex history queries
+jj log -r 'author("alice") & committer_date(after:"2024-01")'
+jj log -r 'description(glob:"fix*") ~ author("bot")'
+jj log -r 'mutable() & empty()'
+```
+
+### Git Compatibility
+
+```bash
+# Use Git commands in colocated workspace
+git status  # Works alongside jj
+git log     # Git view of history
+jj log      # jj view (more powerful)
+
+# Import/export when needed
+jj git import  # Import Git refs
+jj git export  # Export to Git
+
+# Disable/enable colocation
+jj git colocation disable  # Separate .jj directory
+jj git colocation enable   # Shared working copy
+```
+
+## Common Mistakes
+
+- **Using Git staging concepts**: jj has no staging area - changes are automatically tracked in working copy commit
+- **Forgetting to track remote bookmarks**: Use `jj bookmark track <name> --remote origin` for push/pull workflows  
+- **Not using `--colocate`**: Required for Git tool compatibility and GitHub workflows
+- **Expecting `git pull` equivalent**: Use `jj git fetch` followed by `jj rebase -b branch -d main@origin`
+- **Creating commits without descriptions**: Use `jj describe -m "message"` to set commit messages
+- **Mixing `new` and `commit`**: `jj new` finalizes current work, `jj commit` is for colocated Git sync


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/` with vendored copies of authored skills (`graphite-atomic`, `jj-vcs-comprehensive`) so the canonical source lives in the repo.
- Adds `.claude/skills/README.md` — a portable registry of external skills, plugin marketplaces (mine vs third-party), and installed plugins, plus a "rebuild on a fresh machine" section.
- `.claude/skills/` is also auto-loaded by Claude Code in this repo, so the vendored skills are live here as well as backed up.

## Test plan
- [ ] Confirm `graphite-atomic` and `jj-vcs-comprehensive` directories render correctly on GitHub
- [ ] Spot-check a few marketplace/plugin rows in the README against `~/.claude/plugins/installed_plugins.json`
- [ ] Backfill TODO install sources for standalone skills (e.g. `firecrawl-*`) in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Graphite-focused guides: setup, command mappings, commit sizing, conflict resolution, multi-agent stack workflows, and operational checklists.
  * Added Graphite “atomic” skill guidance for atomic commit/stack workflows, conflict handling, recovery, and command references.
  * Added Jujutsu (jj) VCS guidance for Git-interoperable workflows, conflict handling, advanced operations, and common pitfalls.
  * Added a Claude skills reconstruction guide documenting vendored/external skills, plugin marketplaces, install/rebuild checklist, and operational notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors authored Claude Code skills and adds a portable skills/plugins registry so the setup is versioned and easy to rebuild. Also updates `gt`/`jj` docs and enforces a persistent “no manual git merge” rule via CLAUDE.md and a PreToolUse hook.

- **New Features**
  - Added `.claude/skills/` with `graphite-atomic` and `jj-vcs-comprehensive`; skills auto-load in this repo.
  - Added `.claude/skills/README.md` listing external skills, marketplaces, installed plugins, and rebuild steps.

- **Bug Fixes**
  - Fixed `gt`/`jj` docs: added `gt abort`; replaced invalid `gt restack --abort`; clarified `gt create -a` vs `-um`; corrected `jj commit`; removed a dangling README reference.
  - Enforced “no manual `git merge`”: anchored in the CLAUDE.md template and updated the PreToolUse hook to block `git merge` alongside commit/push/rebase, with POSIX-safe word boundaries for BSD `grep`.
  - Polish: `cflx` apply_prompt fenced block now uses `text`; added a non-interactive auth probe (`gt submit --dry-run --no-interactive`) with caveats.

<sup>Written for commit e926c744f4d58e2589df82883369b60b768ad9dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

