### PR TITLE
docs(graphite-atomic): add typical-session recipe, merge paths, speed tips

### DIFF
--- a/.claude/skills/graphite-atomic/SKILL.md
+++ b/.claude/skills/graphite-atomic/SKILL.md
@@ -28,6 +28,44 @@ This check uses `--git-common-dir` instead of `.git/.graphite_repo_config` direc
 7. **Trunk is whatever `gt trunk` reports.** Never assume `main`. Never assume `dev`. If `gt trunk` returns no value, the repo is not initialised. See the activation rule above.
 8. **Amend only for review feedback on the current PR.** `gt modify -a` updates the current branch with staged changes. For anything else, create a new branch with `gt create -am`.
 
+## Typical session
+
+The end-to-end happy path for a stacked-PR session. Run these in order:
+
+```bash
+# 1. Pick up trunk before you start (avoids stale-base stacks)
+gt sync --no-interactive --force
+
+# 2. Work on the first logical unit. When done, stage ONLY the files
+#    that belong in this commit — not the whole tree. Most sessions carry
+#    .claude/, graphify-out/, lock files, or scratch edits that must not
+#    enter the commit. `gt create -am` would sweep them all in.
+git status                           # verify what's modified
+git add <files-for-this-unit>        # selective stage
+gt create -m "<conv-commit-subject>" # -m, NOT -am — preserves the selection
+
+# 3. Repeat for each additional logical unit in the stack.
+
+# 4. Publish the stack directly as non-draft PRs (CodeRabbit and other
+#    reviewers skip drafts):
+gt submit --stack --publish --no-interactive
+```
+
+`--publish` is load-bearing. Without it `--no-interactive` creates drafts by
+default, and you have to run `gh pr ready <N>` after every submit to get
+automated reviews running. Always include `--publish` for agent-driven flows.
+
+### Amending on review feedback
+
+```bash
+git add <files-for-the-fix>
+gt modify -a                          # amend current branch
+gt submit --publish --no-interactive  # force-push via Graphite, re-review runs
+```
+
+The force-push after `gt modify` is expected — Graphite manages the refspec.
+No panic at `+` in the push output.
+
 ## Commit boundary in practice
 
 When you have changes staged, before running `git commit` or `gt create`, ask:
@@ -36,7 +74,9 @@ When you have changes staged, before running `git commit` or `gt create`, ask:
 2. Is the diff ≤400 lines?
 3. Does the build still pass at this commit?
 
-If all three are yes, commit via `gt create -am`. If any is no, split or finish the unit first. Worked examples in `references/commit-sizing.md`.
+If all three are yes, commit via `gt create -m` (or `gt create -am` when you
+are certain every tracked modification belongs in this commit). If any answer
+is no, split or finish the unit first. Worked examples in `references/commit-sizing.md`.
 
 ## Retro-split fallback (headless-safe path)
 
@@ -71,12 +111,62 @@ This mirrors the forward path (commit atomically as units land) rather than resc
 Once the stack is ready:
 
 ```bash
-gt submit --stack --no-interactive
+gt submit --stack --publish --no-interactive
 ```
 
-The `--no-interactive` flag skips prompts, safe in non-interactive agent sessions. Drop `--stack` to update only the current branch.
+Flags:
+- `--stack` — submit every branch in the current stack (drop to submit only the current branch).
+- `--publish` — create PRs as ready-for-review, not drafts. Without this, CodeRabbit and other AI reviewers skip the PR until someone marks it ready.
+- `--no-interactive` — safe in agent sessions; skips prompts.
 
 After submit, return the Graphite PR URL to the user, not the GitHub URL. `gt submit` prints a Graphite URL per branch in its output (format `https://app.graphite.dev/github/pr/<owner>/<repo>/<number>/...`). Extract the URL for the stack tip (or the full list if the user wants to navigate the stack) from the command's stdout; do not fabricate a URL from the PR number and GitHub repo path.
+
+## Merging the stack
+
+Three merge paths, in order of preference. Pick the one that matches your setup.
+
+### Option 1 — Graphite merge queue (web-app feature, preferred for real stacks)
+
+If your org has the Graphite GitHub App installed and the merge queue enabled, toggle "merge when ready" on each stacked PR (via app.graphite.dev) — Graphite merges bottom-up and auto-restacks upstream PRs onto trunk as each one lands. No manual cascade. This is the only merge path that handles a multi-PR stack cleanly. Verify with your org admin before assuming it is available — it is not a CLI command, it is a product feature that requires installation.
+
+### Option 2 — Serial bottom-up via `gh pr merge` + `gt sync`
+
+Works without the merge queue, but has a sharp edge.
+
+```bash
+gh pr merge <bottom-PR> --squash --delete-branch
+gt sync --no-interactive --force
+# repeat for the next PR, now the new bottom
+```
+
+**Warning — cascade close.** `--delete-branch` deletes the bottom PR's remote branch. Any stacked PR whose base was that branch is auto-closed by GitHub (its base no longer exists). For multi-PR stacks under this path, either (a) submit every PR with `--base main` instead of stacked, or (b) expect to re-submit each upstream PR after the one below merges (see recovery path below).
+
+**Warning — `gt sync --force` reaps tracking.** After a PR closes (whether merged or auto-closed), `gt sync --force` deletes the local tracking for that branch. If the commits are still on your disk (e.g. an auto-closed upstream PR whose work you want to re-submit), note the branch's old base SHA **before** running `gt sync --force`, because the branch reference itself may be pruned.
+
+### Option 3 — Recovery from auto-closed stacked PR
+
+Your upstream PR auto-closed when its base branch was deleted. The commits still exist but the PR is dead and cannot be reopened. Rebuild on top of fresh trunk:
+
+```bash
+# 1. Find the old base SHA if you didn't record it before gt sync --force.
+#    Reflog for the dead branch shows its recent HEADs.
+git reflog show <dead-branch-name>
+
+# 2. Create a fresh branch from the current HEAD of the dead one.
+git checkout <dead-branch-name>      # if it still exists locally
+git checkout -b <fresh-branch-name>
+
+# 3. Tell Graphite this branch sits on main.
+gt track --parent main
+
+# 4. Rebase its commits off the (deleted) old base onto current main.
+git rebase --onto main <old-base-sha> HEAD
+
+# 5. Submit as a fresh non-draft PR.
+gt submit --publish --no-interactive
+```
+
+`gt track` only updates tracking metadata — it accepts whatever shape git reports, so rebasing before or after is fine. The old base SHA is the one thing that must not be lost; keep it recorded before any `gt sync --force` in a merge session.
 
 ## Conflicts
 
@@ -89,17 +179,28 @@ Full policy in `references/conflict-resolution.md`.
 
 Read `references/setup.md`. It covers installing `gt`, running `gt init --trunk <trunk>` with a version gate, `gt auth` via browser OAuth (credential-safe), anchoring the skill directive in the project's `CLAUDE.md`, the optional protective PreToolUse hook (fail-closed pattern), and consumer clauses for cflx `apply_prompt` and sauron waves.
 
+## Speed tips
+
+Review cycles iterate quickly when you skip gates that don't add signal:
+
+- **`SKIP_PREPUSH=1 gt submit …`** — on repos where the pre-push hook runs an iOS/Xcode build or other heavy suite, skip it for pure-backend (e.g. Supabase edge-function) stacks. The full build gates the iOS side, not backend correctness. Only skip when you know the diff doesn't touch the iOS side.
+- **`SKIP_AI_REVIEW=1 gt create … / gt modify …`** — during a batch session where you are about to make several commits and already ran type-check / tests locally, per-commit AI review on the staged diff is redundant. The PR-level review will still run. Project CLAUDE.md typically documents when this is acceptable.
+- **Amend-then-submit is one round trip.** Stage all review-fix edits, `gt modify -a` once, `gt submit --publish --no-interactive` once. Don't `gt modify` after each individual fix in the same round — every `gt submit` triggers a force-push plus a ~2-3 min pre-push gate.
+
 ## Quick reference
 
 | Intent | Command |
 |---|---|
-| Start new branch + commit | `gt create -am "<subject>"` |
-| Amend the current PR | `gt modify -a` |
+| Start new branch + commit (selective stage — default) | `git add <files>; gt create -m "<subject>"` |
+| Start new branch + commit (sweep all tracked changes) | `gt create -am "<subject>"` |
+| Amend the current PR | `git add <files>; gt modify` (or `gt modify -a` to sweep) |
 | Add another commit on the same branch | `gt modify -c -am "<subject>"` |
-| Publish the whole stack | `gt submit --stack --no-interactive` |
-| Pull trunk and restack | `gt sync` |
+| Publish the whole stack as non-draft PRs | `gt submit --stack --publish --no-interactive` |
+| Pull trunk and restack | `gt sync --no-interactive --force` |
 | Show the stack | `gt log` |
 | Navigate up/down | `gt up` / `gt down` |
+| Track an untracked branch | `gt track --parent <trunk-or-parent>` |
 | Split an existing commit (headless) | See "Retro-split fallback" above |
+| Recover an auto-closed stacked PR | See "Merging the stack → Option 3" above |
 
 Full table with notes in `references/command-mapping.md`.


### PR DESCRIPTION
## Summary

The `graphite-atomic` skill had the principles but no operational recipe. Running a first stacked-PR session in another repo today exposed the gaps — agents reasoned from scratch each step, hit avoidable traps, and the skill was silent on several recoverable failure modes.

## Gaps observed

- **No end-to-end recipe.** Agent had to reinvent the happy path on every stack action.
- **Draft PRs by default.** `gt submit --no-interactive` creates drafts; CodeRabbit and other AI reviewers skip drafts, so nothing reviews until someone runs `gh pr ready <N>`.
- **Stacked PR auto-close.** `gh pr merge <bottom> --delete-branch` auto-closed the PR stacked on top because GitHub closes PRs whose base branch ceases to exist. Recovery was undocumented.
- **`.claude/`, `graphify-out/`, lock files swept into commits.** `gt create -am` stages all tracked modifications; selective staging (`git add <files>` + `gt create -m`) was the correct everyday pattern but was buried in a "retro-split fallback" section.
- **No guidance on `SKIP_PREPUSH=1` / `SKIP_AI_REVIEW=1`** for batch sessions or backend-only stacks where the full pre-push gate isn't a meaningful signal.

## Changes

1. **New "Typical session" section** — ordered recipe from `gt sync --no-interactive --force` → selective `git add` → `gt create -m` → `gt submit --stack --publish --no-interactive`. Includes an "Amending on review feedback" block.
2. **New "Merging the stack" section** — three paths: Graphite merge queue (preferred, web-app / GitHub App feature — explicitly gated as such, not a CLI command); serial bottom-up via `gh pr merge` + `gt sync` (with **cascade-close** and **`gt sync --force` tracking-reap** warnings); recovery from auto-close via `git reflog` + `gt track --parent main` + `git rebase --onto main <old-base-sha> HEAD` + fresh `gt submit --publish`.
3. **New "Speed tips" section** — `SKIP_PREPUSH=1` for backend-only stacks, `SKIP_AI_REVIEW=1` for batch sessions, and guidance to batch amends into one `gt modify -a` + `gt submit` per review round instead of submitting after each individual fix.
4. **Quick reference table updated** — selective staging leads, `--publish` added to the submit row, `gt track` added, recovery path cross-linked.

Core rules, conflict policy, and setup/reference docs untouched.

## Debate

This patch went through an adversarial review (Sauron/Saruman debate). Concessions absorbed into the patch:
- Merge queue claim gated as "web-app feature, requires installation" rather than presented as a CLI option.
- Recovery recipe explicitly documents `git reflog show <branch>` for recovering the old base SHA after a branch deletion.
- Speed tips added to cover the `gt submit` force-push-every-amend cost.
- `gt sync --force` tracking-reap warning added.
- Selective-staging promotion kept — the `.gitignore` argument doesn't cover `.claude/scheduled_tasks.lock`, `graphify-out/`, scratch edits, etc. Teaching selective staging as default prevents a silent class of bad commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an end-to-end “Typical session” recipe and merge guidance to the `graphite-atomic` skill to prevent draft PRs, cascade closes, and accidental staging. Improves reliability and speed for stacked-PR sessions.

- **New Features**
  - Typical session: `gt sync --no-interactive --force` → selective `git add` → `gt create -m` → `gt submit --stack --publish --no-interactive`, plus amend flow with `gt modify -a`.
  - Merging the stack: three paths (Graphite merge queue; serial `gh pr merge` + `gt sync`), with warnings on cascade-close and tracking reap; recovery via `git reflog`, `gt track --parent main`, `git rebase --onto`, then `gt submit --publish`.
  - Speed tips: `SKIP_PREPUSH=1` for backend-only stacks, `SKIP_AI_REVIEW=1` for batch sessions, batch amends into one `gt modify -a` + `gt submit`.
  - Quick reference: promote selective staging (`git add` + `gt create -m`), add `--publish` to submit, include `gt track`, update `gt sync --no-interactive --force`, and link recovery path.

<sup>Written for commit 30d90876d02530e4ba4bb184e5201e712c1ebffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive workflow guidance including typical session steps, staging strategies, and commit processes.
  * Extended PR maintenance with amend and re-review workflows.
  * Added stack merge instructions with multiple merge strategies.
  * Updated commit-boundary guidance and quick-reference command table.
  * Added performance optimization tips for streamlined workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->