### PR TITLE
chore(gitignore): ignore per-clone Claude state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 __pycache__/
 *.pyc
+
+# Per-clone Claude state (not shared)
+.claude/worktrees/
+.claude/*.local.md
+.claude/*.local.json


### PR DESCRIPTION
## Summary

Adds .gitignore patterns for files that are per-clone but were leaving the working tree dirty:

- \`.claude/worktrees/\` — agent worktree storage
- \`.claude/*.local.md\` — per-clone local notes (e.g. \`ralph-wiggum.local.md\`)
- \`.claude/*.local.json\` — per-clone local settings (future-proofing)

## Note on settings.local.json

\`.claude/settings.local.json\` is already tracked from a prior commit and stays tracked here to avoid wiping other clones' local settings on next pull. To untrack intentionally:

\`\`\`bash
git rm --cached .claude/settings.local.json
\`\`\`

That belongs in a follow-up if/when we want to make the convention strict for everyone.

## Test plan

- [ ] \`git check-ignore -v .claude/worktrees/ .claude/ralph-wiggum.local.md\` shows the new patterns matching
- [ ] Working tree is clean after this change (modulo the still-tracked \`settings.local.json\` if it's been edited locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gitignore configuration to exclude local development workspace files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .gitignore rules for per-clone Claude state to keep the working tree clean. Ignores `.claude/worktrees/`, `.claude/*.local.md`, and `.claude/*.local.json`.

- **Migration**
  - Optional: `.claude/settings.local.json` remains tracked; to stop tracking it later, run `git rm --cached .claude/settings.local.json`.

<sup>Written for commit 52435580a7e061a75d152b09bf244994a07784f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

