### PR TITLE
docs(skills): document cross-tool layout (Claude + Codex shared canonical)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -2,14 +2,30 @@
 
 Portable reference for George's Claude Code coding setup. Skill folders under this directory are vendored copies of skills authored by me. The rest is a registry of external skills and plugins I use, with install sources so this setup can be reconstructed on a fresh machine.
 
+## Where skills live (cross-tool layout)
+
+Three search roots in play across the tools I use:
+
+| Tool | Discovery |
+|---|---|
+| **Claude Code** | auto-scans `~/.claude/skills/` (global) and `<project>/.claude/skills/` (project-scoped, e.g. this repo). |
+| **Codex** | explicit `[[skills.config]]` blocks in `~/.codex/config.toml` — one per skill, no auto-scan. |
+| **Shared canonical** | `~/.agents/skills/` — single source-of-truth for skills used by **both** tools. |
+
+**Convention for cross-tool skills**: canonical lives at `~/.agents/skills/<name>/`. Claude picks it up via a symlink at `~/.claude/skills/<name> → ../../.agents/skills/<name>`. Codex picks it up via a `[[skills.config]]` block pointing at the absolute `~/.agents/skills/<name>/SKILL.md` path. Edit the canonical once, both tools see the change.
+
+**Currently shared via this pattern**: `firecrawl` (+ `firecrawl-*` sub-skills), `graphite-pr`. Everything else is single-tool (mostly Claude-only at `~/.claude/skills/`).
+
+**Vendoring rule**: skills I author are vendored into this repo (`./graphite-pr/`, `./jj-vcs-comprehensive/`) as the version-controlled source. The runtime canonical (e.g. `~/.agents/skills/graphite-pr/`) is what Claude/Codex actually load. Rebuild flow on a fresh machine: clone repo → copy vendored dir to runtime canonical → wire up Claude symlink and Codex `[[skills.config]]` block.
+
 ## Skills authored by me (vendored here)
 
-| Skill | Trigger / Scope | Upstream |
-|---|---|---|
-| [`graphite-pr/`](./graphite-pr/) | Stacked PRs via `gt` — daily commit→submit→review→merge loop. Active in `.graphite_repo_config` repos or on `gt`/stacked-PR cues. Renamed from `graphite-atomic` Apr 2026. | `~/.claude/skills/graphite-pr/` |
-| [`jj-vcs-comprehensive/`](./jj-vcs-comprehensive/) | Jujutsu (jj) VCS — colocated workspaces, bookmarks, GitHub sync, conflict resolution. | `~/.claude/skills/jj-vcs-comprehensive/` |
+| Skill | Trigger / Scope | Runtime canonical | Sharing |
+|---|---|---|---|
+| [`graphite-pr/`](./graphite-pr/) | Stacked PRs via `gt` — daily commit→submit→review→merge loop. Active in `.graphite_repo_config` repos or on `gt`/stacked-PR cues. Renamed from `graphite-atomic` Apr 2026. | `~/.agents/skills/graphite-pr/` | **shared** (Claude via symlink, Codex via `config.toml` entry) |
+| [`jj-vcs-comprehensive/`](./jj-vcs-comprehensive/) | Jujutsu (jj) VCS — colocated workspaces, bookmarks, GitHub sync, conflict resolution. | `~/.claude/skills/jj-vcs-comprehensive/` | Claude only |
 
-These are committed into the repo so the canonical source is versioned. To update, edit in place here and copy out to `~/.claude/skills/<name>/` (or symlink during local dev).
+These are committed into the repo so the canonical source is versioned. To update: edit in place here, then mirror to the runtime canonical above. For shared skills, that's the single shared dir — both tools pick up the change.
 
 ## External skills I use
 
@@ -17,7 +33,7 @@ Installed directly under `~/.claude/skills/` (not via a plugin). Source/install 
 
 | Skill | Purpose | Source |
 |---|---|---|
-| `firecrawl`, `firecrawl-scrape`, `firecrawl-search`, `firecrawl-map`, `firecrawl-crawl`, `firecrawl-agent`, `firecrawl-interact`, `firecrawl-download` | Web scraping / search / crawl via Firecrawl CLI | Firecrawl (likely `skills.sh` or Firecrawl docs) |
+| `firecrawl`, `firecrawl-scrape`, `firecrawl-search`, `firecrawl-map`, `firecrawl-crawl`, `firecrawl-agent`, `firecrawl-interact`, `firecrawl-download` | Web scraping / search / crawl via Firecrawl CLI. **Shared** — canonical at `~/.agents/skills/firecrawl*`, Claude via symlinks, Codex via `config.toml`. | Firecrawl (likely `skills.sh` or Firecrawl docs) |
 | `nlm-skill` | NotebookLM CLI + MCP (`nlm`) | NotebookLM MCP package |
 | `sketch-implement-design` | Translate Sketch layers → code via Sketch MCP | Sketch MCP server |
 | `cmux-theme` | cmux terminal multiplexer | cmux.app distribution |
@@ -128,17 +144,29 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 
 ## Rebuilding this setup on a fresh machine
 
-1. Install Claude Code CLI.
+1. Install Claude Code CLI (and Codex CLI if dual-tool setup).
 2. Add the marketplaces listed above (`/plugin marketplace add <repo>`).
 3. Install plugins from each marketplace.
-4. Copy the vendored skills here into `~/.claude/skills/`:
+4. Restore vendored skills:
 
    ```bash
-   cp -r .claude/skills/graphite-pr ~/.claude/skills/
+   # Shared (used by both Claude and Codex) — canonical lives in ~/.agents/skills/
+   mkdir -p ~/.agents/skills
+   cp -r .claude/skills/graphite-pr ~/.agents/skills/
+   ln -s ../../.agents/skills/graphite-pr ~/.claude/skills/graphite-pr
+
+   # Claude-only — copy straight into ~/.claude/skills/
    cp -r .claude/skills/jj-vcs-comprehensive ~/.claude/skills/
    ```
 
-5. Reinstall any standalone `~/.claude/skills/` entries from the External skills table above (most likely via `skills.sh` or their upstream docs).
+5. Wire shared skills into Codex by appending to `~/.codex/config.toml`:
+
+   ```toml
+   [[skills.config]]
+   path = "/Users/<you>/.agents/skills/graphite-pr/SKILL.md"
+   ```
+
+6. Reinstall any standalone `~/.claude/skills/` entries from the External skills table above (most likely via `skills.sh` or their upstream docs). For shared external skills (firecrawl), install once into `~/.agents/skills/` and wire both tools the same way as above.
 
 ## Notes
 

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -162,7 +162,7 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 
    # Shared (used by both Claude and Codex) — canonical lives in ~/.agents/skills/.
    cp -r .claude/skills/graphite-pr ~/.agents/skills/
-   ln -s "$HOME/.agents/skills/graphite-pr" "$HOME/.claude/skills/graphite-pr"
+   ln -sfn "$HOME/.agents/skills/graphite-pr" "$HOME/.claude/skills/graphite-pr"
 
    # Claude-only — copy straight into ~/.claude/skills/.
    cp -r .claude/skills/jj-vcs-comprehensive ~/.claude/skills/
@@ -171,12 +171,16 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 5. Wire shared skills into Codex. Back up first, then append (Codex has no auto-scan; every shared skill needs its own block):
 
    ```bash
-   touch ~/.codex/config.toml   # in case Codex has never been launched
+   mkdir -p ~/.codex
+   touch ~/.codex/config.toml
    cp ~/.codex/config.toml ~/.codex/config.toml.bak.$(date +%s)
-   cat >> ~/.codex/config.toml <<EOF
+
+   # Idempotent append — only adds the block if this skill's path isn't already registered.
+   SKILL_PATH="$HOME/.agents/skills/graphite-pr/SKILL.md"
+   grep -qF "$SKILL_PATH" ~/.codex/config.toml || cat >> ~/.codex/config.toml <<EOF
 
    [[skills.config]]
-   path = "$HOME/.agents/skills/graphite-pr/SKILL.md"
+   path = "$SKILL_PATH"
    enabled = true
    EOF
    ```

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -154,7 +154,7 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 1. Install Claude Code CLI (and Codex CLI if dual-tool setup).
 2. Add the marketplaces listed above (`/plugin marketplace add <repo>`).
 3. Install plugins from each marketplace.
-4. Restore vendored skills:
+4. Restore vendored skills (run from the cloned repo root):
 
    ```bash
    # Ensure target dirs exist (fresh installs may not have them).

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -4,19 +4,19 @@ Portable reference for George's Claude Code coding setup. Skill folders under th
 
 ## Where skills live (cross-tool layout)
 
-Three search roots in play across the tools I use:
+Three search roots:
 
 | Tool | Discovery |
 |---|---|
-| **Claude Code** | auto-scans `~/.claude/skills/` (global) and `<project>/.claude/skills/` (project-scoped, e.g. this repo). |
-| **Codex** | explicit `[[skills.config]]` blocks in `~/.codex/config.toml` — one per skill, no auto-scan. |
-| **Shared canonical** | `~/.agents/skills/` — single source-of-truth for skills used by **both** tools. |
+| **Claude Code** | auto-scans `~/.claude/skills/` (global) and `<project>/.claude/skills/` (project-scoped). |
+| **Codex** | explicit `[[skills.config]]` blocks in `~/.codex/config.toml` — no auto-scan. |
+| **Shared canonical** | `~/.agents/skills/` — single source for skills used by **both** tools. |
 
-**Convention for cross-tool skills**: canonical lives at `~/.agents/skills/<name>/`. Claude picks it up via a symlink at `~/.claude/skills/<name> → ../../.agents/skills/<name>`. Codex picks it up via a `[[skills.config]]` block pointing at the absolute `~/.agents/skills/<name>/SKILL.md` path. Edit the canonical once, both tools see the change.
+For cross-tool skills: canonical lives at `~/.agents/skills/<name>/`; Claude reads it via a symlink at `~/.claude/skills/<name>`, Codex via a `[[skills.config]]` block pointing at the absolute `SKILL.md` path. Edit once, both tools update.
 
-**Currently shared via this pattern**: `firecrawl` (+ `firecrawl-*` sub-skills), `graphite-pr`. Everything else is single-tool (mostly Claude-only at `~/.claude/skills/`).
+Currently shared: `firecrawl` (+ `firecrawl-*`), `graphite-pr`. Everything else is Claude-only at `~/.claude/skills/`.
 
-**Vendoring rule**: skills I author are vendored into this repo (`./graphite-pr/`, `./jj-vcs-comprehensive/`) as the version-controlled source. The runtime canonical (e.g. `~/.agents/skills/graphite-pr/`) is what Claude/Codex actually load. Rebuild flow on a fresh machine: clone repo → copy vendored dir to runtime canonical → wire up Claude symlink and Codex `[[skills.config]]` block.
+Skills I author are vendored into this repo as the versioned source; the runtime canonical is what the tools actually load. See "Rebuilding this setup" below for the wiring steps.
 
 ## Skills authored by me (vendored here)
 
@@ -25,7 +25,14 @@ Three search roots in play across the tools I use:
 | [`graphite-pr/`](./graphite-pr/) | Stacked PRs via `gt` — daily commit→submit→review→merge loop. Active in `.graphite_repo_config` repos or on `gt`/stacked-PR cues. Renamed from `graphite-atomic` Apr 2026. | `~/.agents/skills/graphite-pr/` | **shared** (Claude via symlink, Codex via `config.toml` entry) |
 | [`jj-vcs-comprehensive/`](./jj-vcs-comprehensive/) | Jujutsu (jj) VCS — colocated workspaces, bookmarks, GitHub sync, conflict resolution. | `~/.claude/skills/jj-vcs-comprehensive/` | Claude only |
 
-These are committed into the repo so the canonical source is versioned. To update: edit in place here, then mirror to the runtime canonical above. For shared skills, that's the single shared dir — both tools pick up the change.
+**Update discipline**: edit the vendored copy here first (so the change is committed), then mirror to the runtime canonical:
+
+```bash
+cp -r .claude/skills/<name>/ ~/.agents/skills/<name>/   # shared skills
+cp -r .claude/skills/<name>/ ~/.claude/skills/<name>/   # Claude-only skills
+```
+
+For shared skills the single mirror reaches both tools.
 
 ## External skills I use
 
@@ -33,7 +40,7 @@ Installed directly under `~/.claude/skills/` (not via a plugin). Source/install 
 
 | Skill | Purpose | Source |
 |---|---|---|
-| `firecrawl`, `firecrawl-scrape`, `firecrawl-search`, `firecrawl-map`, `firecrawl-crawl`, `firecrawl-agent`, `firecrawl-interact`, `firecrawl-download` | Web scraping / search / crawl via Firecrawl CLI. **Shared** — canonical at `~/.agents/skills/firecrawl*`, Claude via symlinks, Codex via `config.toml`. | Firecrawl (likely `skills.sh` or Firecrawl docs) |
+| `firecrawl`, `firecrawl-scrape`, `firecrawl-search`, `firecrawl-map`, `firecrawl-crawl`, `firecrawl-agent`, `firecrawl-interact`, `firecrawl-download` | Web scraping / search / crawl via Firecrawl CLI. Shared (canonical at `~/.agents/skills/firecrawl*`). | Firecrawl (likely `skills.sh` or Firecrawl docs) |
 | `nlm-skill` | NotebookLM CLI + MCP (`nlm`) | NotebookLM MCP package |
 | `sketch-implement-design` | Translate Sketch layers → code via Sketch MCP | Sketch MCP server |
 | `cmux-theme` | cmux terminal multiplexer | cmux.app distribution |
@@ -150,23 +157,33 @@ Grouped by source marketplace. Scope is `user` unless noted. Install via `/plugi
 4. Restore vendored skills:
 
    ```bash
-   # Shared (used by both Claude and Codex) — canonical lives in ~/.agents/skills/
-   mkdir -p ~/.agents/skills
-   cp -r .claude/skills/graphite-pr ~/.agents/skills/
-   ln -s ../../.agents/skills/graphite-pr ~/.claude/skills/graphite-pr
+   # Ensure target dirs exist (fresh installs may not have them).
+   mkdir -p ~/.agents/skills ~/.claude/skills
 
-   # Claude-only — copy straight into ~/.claude/skills/
+   # Shared (used by both Claude and Codex) — canonical lives in ~/.agents/skills/.
+   cp -r .claude/skills/graphite-pr ~/.agents/skills/
+   ln -s "$HOME/.agents/skills/graphite-pr" "$HOME/.claude/skills/graphite-pr"
+
+   # Claude-only — copy straight into ~/.claude/skills/.
    cp -r .claude/skills/jj-vcs-comprehensive ~/.claude/skills/
    ```
 
-5. Wire shared skills into Codex by appending to `~/.codex/config.toml`:
+5. Wire shared skills into Codex. Back up first, then append (Codex has no auto-scan; every shared skill needs its own block):
 
-   ```toml
+   ```bash
+   touch ~/.codex/config.toml   # in case Codex has never been launched
+   cp ~/.codex/config.toml ~/.codex/config.toml.bak.$(date +%s)
+   cat >> ~/.codex/config.toml <<EOF
+
    [[skills.config]]
-   path = "/Users/<you>/.agents/skills/graphite-pr/SKILL.md"
+   path = "$HOME/.agents/skills/graphite-pr/SKILL.md"
+   enabled = true
+   EOF
    ```
 
-6. Reinstall any standalone `~/.claude/skills/` entries from the External skills table above (most likely via `skills.sh` or their upstream docs). For shared external skills (firecrawl), install once into `~/.agents/skills/` and wire both tools the same way as above.
+   Verify the file still parses: `python3 -c 'import tomllib; tomllib.load(open("'"$HOME"'/.codex/config.toml","rb"))'`.
+
+6. Reinstall standalone entries from the External skills table (mostly via `skills.sh` or upstream docs). Shared external skills install into `~/.agents/skills/` and need both a Claude symlink and a Codex block per skill. For example, the firecrawl set is 8 SKILL.md files (`firecrawl`, `firecrawl-{agent,crawl,download,interact,map,scrape,search}`) — repeat the step-5 append once per skill, swapping the path.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Updates `.claude/skills/README.md` to reflect the actual layout after this session's work, so future updates know what lives where.

**New section: "Where skills live (cross-tool layout)"** — explains the three skill discovery roots:
- `~/.claude/skills/` (Claude Code auto-scan)
- `~/.codex/config.toml` `[[skills.config]]` blocks (Codex explicit registration)
- `~/.agents/skills/` (shared canonical for cross-tool skills)

**Convention**: skills used by both tools live at `~/.agents/skills/<name>/`. Claude reads via a symlink under `~/.claude/skills/`; Codex reads via a `[[skills.config]]` path. Edit the canonical once, both tools see it.

**Currently shared** (now reflected in tables): `firecrawl` (+ sub-skills), `graphite-pr`. Vendored copies in this repo remain the version-controlled source of truth for fresh-machine rebuilds.

**Rebuild instructions updated** to walk through:
1. Copy shared skills to `~/.agents/skills/` + symlink + Codex `[[skills.config]]`
2. Copy Claude-only skills directly to `~/.claude/skills/`

## Test plan
- [x] All section markers and tables render cleanly.
- [x] Markdownlint clean (project disables MD013/024/033/036/060).
- [ ] After merge: a future agent reading this README can reconstruct the layout from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the cross-tool skills layout shared by Claude Code and Codex, setting `~/.agents/skills/` as the canonical location and clarifying discovery for both tools. Rebuild steps are now idempotent and safer with absolute symlinks, guarded Codex config writes, and a clear firecrawl example run from the repo root.

- **Migration**
  - Put shared skills in `~/.agents/skills/<name>/`; Claude symlink: `~/.claude/skills/<name> → $HOME/.agents/skills/<name>`.
  - Create dirs first: `mkdir -p ~/.agents/skills ~/.claude/skills ~/.codex`.
  - Codex: back up, then append `[[skills.config]]` pointing to `$HOME/.agents/skills/<name>/SKILL.md` only if missing; verify parse. Shared today: `graphite-pr`, `firecrawl*` (8 `SKILL.md` files).
  - Idempotency: use `ln -sfn` for symlinks and a pre-check before appending to `~/.codex/config.toml`.
  - Update flow: edit vendored copy, then `cp -r` to the runtime canonical; Claude-only skills go to `~/.claude/skills/`.

<sup>Written for commit 81547563c3566373a22024cf3dc680af05993271. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for cross-tool skill discovery and a canonical shared-skills directory.
  * Extended authored-skills table to show canonical runtime paths and sharing status; marked examples as shared or tool-only.
  * Updated rebuild/reinstall flow to restore vendored skills into the canonical location, create tool-specific links, and register shared skills in other tools with verification.
  * Added commands for mirroring and updating shared skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->