### PR TITLE
chore: tighten recovery.md import wording + ignore session artifacts

### DIFF
--- a/.claude/skills/graphite-pr/references/recovery.md
+++ b/.claude/skills/graphite-pr/references/recovery.md
@@ -86,7 +86,7 @@ This mirrors the forward path (commit atomically as units land) rather than resc
 
 - Whitespace-only or formatter drift
 - Non-overlapping additions in the same file (both sides added different hunks at different locations)
-- Reordered or added imports — but only after confirming none are **side-effect imports** (e.g. `import './polyfills'`, `import 'reflect-metadata'`, CSS imports, anything imported for its evaluation rather than a binding). Side-effect imports are order-sensitive in every language, including JS/TS/Go/Rust where module-level import order is otherwise inert. If the conflict touches a side-effect import, escalate.
+- Reordered or added imports — but only if none are **side-effect imports** (e.g. `import './polyfills'`, `import 'reflect-metadata'`, CSS imports, anything imported for evaluation rather than a binding). These are order-sensitive even in languages where import order is otherwise inert; if the conflict touches one, escalate.
 
 After any auto-resolve, run the build/test gate before continuing. If it fails, revert and escalate.
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ __pycache__/
 .claude/worktrees/
 .claude/*.local.md
 .claude/*.local.json
+.claude/scheduled_tasks.lock
+
+# Session-only coordination artifacts
+docs/strongholds/


### PR DESCRIPTION
## Summary

Cleanup PR addressing leftover working-tree state after the cross-tool skill-sharing work merged in #62:

- **`recovery.md` tightening**: side-effect-import carve-out wording got tightened during the /palantir-debate Reforger pass earlier in the session, but the change only made it to the runtime canonical (`~/.agents/skills/graphite-pr/`) and not to the vendored copy in this repo. This brings them back in sync.
- **`.gitignore`**: add `.claude/scheduled_tasks.lock` (Claude's cron tool runtime artifact, per-session) and `docs/strongholds/` (Sauron protocol session-coordination files, per-session). Both were untracked noise in `git status`.

## Test plan
- [x] `git status` clean after merge.
- [x] Vendored ↔ runtime recovery.md content matches (only cosmetic blank-line drift from formatter).
- [ ] After merge: scheduled_tasks.lock and strongholds/ stay untracked across sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens `recovery.md` guidance for resolving import conflicts and ignores session-only artifacts to keep the working tree clean. Clarifies that reordering/adding imports is safe only when no side-effect imports are involved; adds `.claude/scheduled_tasks.lock` and `docs/strongholds/` to `.gitignore`.

<sup>Written for commit a6d8e4cc14d83f77f6a217117c641c8fbcec688f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation rules for import conflict auto-resolution.
  * Extended version control configuration to exclude additional build artifacts and directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->