### PR TITLE
docs(graphite-pr): reconcile vendored copy with runtime canonical

### DIFF
--- a/.claude/skills/graphite-pr/SKILL.md
+++ b/.claude/skills/graphite-pr/SKILL.md
@@ -86,12 +86,12 @@ For a single PR: never `gh pr merge` blind. Pre-flight first (GraphQL — `gh pr
 ```bash
 NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner); O=${NWO%/*}; R=${NWO#*/}
 gh api graphql \
-  -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewDecision reviewThreads(first:50){nodes{isResolved isOutdated}}}}}' \
+  -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewDecision reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved isOutdated}}}}}' \
   -F o="$O" -F r="$R" -F n=<N> \
-  --jq '{decision: .data.repository.pullRequest.reviewDecision, unresolved: ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length)}'
+  --jq '{decision: .data.repository.pullRequest.reviewDecision, unresolved: ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length), truncated: .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage}'
 ```
 
-Merge only when `unresolved == 0` and `decision != "CHANGES_REQUESTED"` (a `null` decision is fine; it means no formal review yet). Then `gh pr merge <N> --squash --delete-branch`. `gt merge` ignores comment state by default; this gate is the safety net.
+Merge only when the JSON printed above has `unresolved == 0`, `decision != "CHANGES_REQUESTED"`, and `truncated == false` (a `null` decision is fine; it means no formal review yet). Then `gh pr merge <N> --squash --delete-branch`. `gt merge` ignores comment state by default; this gate is the safety net. If `truncated` is true the PR has >100 review threads — paginate via `endCursor` or treat as unsafe to auto-merge.
 
 If the `Graphite / AI Reviews` check hasn't appeared a few minutes after a non-draft PR, surface this before continuing to wait:
 

--- a/.claude/skills/graphite-pr/SKILL.md
+++ b/.claude/skills/graphite-pr/SKILL.md
@@ -111,7 +111,7 @@ gt sync --no-interactive --force
 
 Before `gt sync --force` after a closed PR, record any branch SHA you might still need (`git rev-parse <branch>~`) — sync deletes local tracking for closed branches.
 
-If anything goes sideways, load `references/troubleshooting.md`.
+If anything goes sideways, load `references/recovery.md`.
 
 ## Quick reference
 

--- a/.claude/skills/graphite-pr/SKILL.md
+++ b/.claude/skills/graphite-pr/SKILL.md
@@ -77,35 +77,41 @@ Batch all review fixes into one `gt modify -a` + `gt submit` to avoid multiple r
 
 Amend (`gt modify -a`) for fixes to *this* PR. If the reviewer asks for new scope, that's a new commit on top: `git add <files>; gt create -m "<subject>"`.
 
-## After submit: poll, then merge
+## After submit: merge
 
-The merge gate is `Graphite / AI Reviews`. Poll:
+For a stack, run `scripts/gt-merge-cascade.sh`. It dry-runs to validate, **blocks on unresolved review threads** (one GraphQL count per PR, no comment bodies fetched, low context), runs `gt merge`, polls every 30s, and returns JSON when done. Fails fast on stuck/closed PRs or unresolved threads. Stdout-only, won't bloat your context.
+
+For a single PR: never `gh pr merge` blind. Pre-flight first (GraphQL — `gh pr view` does not expose `reviewThreads`):
 
 ```bash
-gh pr view <N> --json statusCheckRollup
+NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner); O=${NWO%/*}; R=${NWO#*/}
+gh api graphql \
+  -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewDecision reviewThreads(first:50){nodes{isResolved isOutdated}}}}}' \
+  -F o="$O" -F r="$R" -F n=<N> \
+  --jq '{decision: .data.repository.pullRequest.reviewDecision, unresolved: ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length)}'
 ```
 
-`/loop 1m` or `/loop 3m` works for cadence — query `statusCheckRollup` and act when the check goes SUCCESS.
+Merge only when `unresolved == 0` and `decision != "CHANGES_REQUESTED"` (a `null` decision is fine; it means no formal review yet). Then `gh pr merge <N> --squash --delete-branch`. `gt merge` ignores comment state by default; this gate is the safety net.
 
-If the check hasn't appeared a few minutes after a non-draft PR, surface this before continuing to wait:
+If the `Graphite / AI Reviews` check hasn't appeared a few minutes after a non-draft PR, surface this before continuing to wait:
 
 > Graphite auto-review isn't running on PR #N. Likely cause: (1) PR is still draft → `gh pr ready <N>`. (2) Graphite GitHub App not installed in the org. (3) PR exceeds size threshold (~1500+ lines, SIZE_GATED). (4) Repo opted out at app.graphite.dev. Pick one before I keep polling.
 
-Once green, merge by one of:
+Alternative for stacks: use the **Graphite merge queue** — toggle "merge when ready" on each PR at app.graphite.dev. Merges bottom-up and auto-restacks. Requires the Graphite GitHub App.
 
-1. **Graphite merge queue** (preferred for stacks) — toggle "merge when ready" on each PR at app.graphite.dev. Merges bottom-up and auto-restacks. Requires the Graphite GitHub App.
-2. **Bottom-up `gh pr merge`**:
+For bottom-up `gh pr merge` instead of the cascade script:
 
-   ```bash
-   gh pr merge <bottom-PR> --squash --delete-branch
-   gt sync --no-interactive --force
-   # repeat for the next bottom
-   ```
+```bash
+gh pr merge <bottom-PR> --squash --delete-branch
+gt sync --no-interactive --force
+# repeat for the next bottom
+```
 
-   `--delete-branch` cascade-closes any PR stacked on top. To avoid: submit every PR with `--base $(gt trunk)` instead. To recover after cascade: `references/recovery.md`.
-3. **Single PR**: `gh pr merge <N> --squash --delete-branch`.
+`--delete-branch` cascade-closes any PR stacked on top. To avoid: submit every PR with `--base $(gt trunk)` instead. To recover after cascade: `references/recovery.md`.
 
 Before `gt sync --force` after a closed PR, record any branch SHA you might still need (`git rev-parse <branch>~`) — sync deletes local tracking for closed branches.
+
+If anything goes sideways, load `references/troubleshooting.md`.
 
 ## Quick reference
 
@@ -118,7 +124,8 @@ Before `gt sync --force` after a closed PR, record any branch SHA you might stil
 | Pull trunk and restack | `gt sync --no-interactive --force` |
 | Show the stack | `gt log` |
 | Trunk name (use, don't assume) | `gt trunk` |
-| Track an untracked branch | `gt track --parent "$(gt trunk)"` |
+| Track an untracked branch (first one in repo) | `gt track --parent <trunk-name>` — `gt trunk` errors when HEAD itself is untracked, so pass the trunk literally (`main`/`dev`/etc.) the first time |
+| Track an untracked branch (stack already exists) | `gt track --parent "$(gt trunk)"` |
 | Continue after conflict resolution | `gt continue` |
 | Abort an in-flight restack | `gt abort` |
 

--- a/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
+++ b/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
@@ -12,16 +12,19 @@
 
 set -eu
 
-POLL_INTERVAL="${1:-30}"
-TIMEOUT_MINUTES="${2:-30}"
-TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
-
 json_str() { jq -Rs . <<<"$1"; }
 
 fail() {
     printf '{"result":"failed","reason":%s,"detail":%s}\n' "$(json_str "$1")" "$(json_str "${2:-}")"
     exit 1
 }
+
+# Validate CLI inputs before arithmetic / sleep so failures preserve the JSON contract.
+POLL_INTERVAL="${1:-30}"
+TIMEOUT_MINUTES="${2:-30}"
+[[ "$POLL_INTERVAL"   =~ ^[1-9][0-9]*$ ]] || fail "invalid-poll-interval"   "must be a positive integer; got: $POLL_INTERVAL"
+[[ "$TIMEOUT_MINUTES" =~ ^[1-9][0-9]*$ ]] || fail "invalid-timeout-minutes" "must be a positive integer; got: $TIMEOUT_MINUTES"
+TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
 
 # 1. Validate stack is ready
 DRY_RUN="$(gt merge --dry-run 2>&1)" || fail "dry-run-error" "$DRY_RUN"

--- a/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
+++ b/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# gt-merge-cascade — run gt merge and poll until cascade completes.
+#
+# Usage: gt-merge-cascade [poll-interval-seconds] [timeout-minutes]
+#   defaults: poll=30s, timeout=30m
+#
+# Stdout (JSON):
+#   success: {"result":"success","total_seconds":N,"pr_count":N,"per_pr_seconds":{"288":120,...}}
+#   failure: {"result":"failed","reason":"...","detail":"..."}
+#
+# Exit: 0 on success, non-zero on failure.
+
+set -eu
+
+POLL_INTERVAL="${1:-30}"
+TIMEOUT_MINUTES="${2:-30}"
+TIMEOUT_SECONDS=$((TIMEOUT_MINUTES * 60))
+
+json_str() { jq -Rs . <<<"$1"; }
+
+fail() {
+    printf '{"result":"failed","reason":%s,"detail":%s}\n' "$(json_str "$1")" "$(json_str "${2:-}")"
+    exit 1
+}
+
+# 1. Validate stack is ready
+DRY_RUN="$(gt merge --dry-run 2>&1)" || fail "dry-run-error" "$DRY_RUN"
+grep -q "Your stack is ready to merge" <<<"$DRY_RUN" || fail "stack-not-ready" "$DRY_RUN"
+
+# 2. Extract branch list from dry-run
+BRANCHES=$(awk '/Preparing to merge:/{f=1; next} /Dry run complete/{f=0} f && /^▸/ {print $2}' <<<"$DRY_RUN")
+[ -n "$BRANCHES" ] || fail "no-branches-found" "could not parse dry-run output"
+
+# 3. Map each branch to its PR number
+PR_LIST=()
+for branch in $BRANCHES; do
+    pr=$(gh pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null || true)
+    [ -n "$pr" ] && PR_LIST+=("$pr")
+done
+[ "${#PR_LIST[@]}" -gt 0 ] || fail "no-open-prs" "stack branches have no open PRs"
+
+# 3a. Gate on unresolved review threads. `gt merge` ignores them; we don't.
+#     One GraphQL call per PR; returns only an integer count, so context cost is tiny.
+REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || fail "no-repo" "could not resolve owner/repo"
+REPO_OWNER="${REPO_NWO%/*}"
+REPO_NAME="${REPO_NWO#*/}"
+UNRESOLVED_DETAIL=""
+for pr in "${PR_LIST[@]}"; do
+    n=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:50){nodes{isResolved isOutdated}}}}}' \
+        -F o="$REPO_OWNER" -F r="$REPO_NAME" -F n="$pr" \
+        --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length' 2>/dev/null || echo "ERR")
+    [ "$n" = "ERR" ] && fail "graphql-error" "could not query review threads for PR #$pr"
+    [ "$n" -gt 0 ] && UNRESOLVED_DETAIL+="#${pr}:${n} "
+done
+[ -z "$UNRESOLVED_DETAIL" ] || fail "unresolved-review-threads" "resolve threads before merging: ${UNRESOLVED_DETAIL}"
+
+# 4. Kick off cascade (returns quickly; merge happens server-side)
+START_TIME=$(date +%s)
+gt merge --no-interactive >/dev/null 2>&1 || fail "gt-merge-failed" "gt merge command returned non-zero"
+
+# 5. Poll until all merged, any close without merge, or timeout
+declare -A MERGED_AT
+while true; do
+    NOW=$(date +%s)
+    ELAPSED=$((NOW - START_TIME))
+    [ "$ELAPSED" -gt "$TIMEOUT_SECONDS" ] && fail "timeout" "exceeded ${TIMEOUT_MINUTES}m; check 'gt log' for stuck PRs"
+
+    all_merged=true
+    for pr in "${PR_LIST[@]}"; do
+        [ -n "${MERGED_AT[$pr]:-}" ] && continue
+        state=$(gh pr view "$pr" --json state -q .state 2>/dev/null || echo "ERROR")
+        case "$state" in
+            MERGED) MERGED_AT[$pr]=$NOW ;;
+            CLOSED) fail "pr-closed-without-merge" "PR #$pr closed without merging mid-cascade" ;;
+            OPEN)   all_merged=false ;;
+            ERROR)  all_merged=false ;;  # transient API error; retry next tick
+            *)      fail "unexpected-state" "PR #$pr returned state: $state" ;;
+        esac
+    done
+
+    if $all_merged; then
+        END_TIME=$(date +%s)
+        DURATION=$((END_TIME - START_TIME))
+
+        # Build per-PR JSON object
+        per_pr="{"
+        first=true
+        for pr in "${PR_LIST[@]}"; do
+            $first || per_pr+=","
+            per_pr+="\"$pr\":$(( MERGED_AT[$pr] - START_TIME ))"
+            first=false
+        done
+        per_pr+="}"
+
+        printf '{"result":"success","total_seconds":%d,"pr_count":%d,"per_pr_seconds":%s}\n' \
+            "$DURATION" "${#PR_LIST[@]}" "$per_pr"
+        exit 0
+    fi
+
+    sleep "$POLL_INTERVAL"
+done

--- a/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
+++ b/.claude/skills/graphite-pr/scripts/gt-merge-cascade.sh
@@ -31,28 +31,44 @@ grep -q "Your stack is ready to merge" <<<"$DRY_RUN" || fail "stack-not-ready" "
 BRANCHES=$(awk '/Preparing to merge:/{f=1; next} /Dry run complete/{f=0} f && /^▸/ {print $2}' <<<"$DRY_RUN")
 [ -n "$BRANCHES" ] || fail "no-branches-found" "could not parse dry-run output"
 
-# 3. Map each branch to its PR number
+# 3. Map each branch to its PR number. Whitespace/glob-safe; loud on missing PRs.
 PR_LIST=()
-for branch in $BRANCHES; do
+MISSING_PRS=()
+while IFS= read -r branch; do
+    [ -z "$branch" ] && continue
     pr=$(gh pr list --head "$branch" --state open --json number -q '.[0].number' 2>/dev/null || true)
-    [ -n "$pr" ] && PR_LIST+=("$pr")
-done
+    if [ -n "$pr" ]; then
+        PR_LIST+=("$pr")
+    else
+        MISSING_PRS+=("$branch")
+    fi
+done <<<"$BRANCHES"
+[ "${#MISSING_PRS[@]}" -eq 0 ] || fail "stack-branch-without-pr" "no open PR for branches: ${MISSING_PRS[*]}"
 [ "${#PR_LIST[@]}" -gt 0 ] || fail "no-open-prs" "stack branches have no open PRs"
 
-# 3a. Gate on unresolved review threads. `gt merge` ignores them; we don't.
-#     One GraphQL call per PR; returns only an integer count, so context cost is tiny.
+# 3a. Gate on unresolved threads, CHANGES_REQUESTED reviews, and pagination truncation.
+#     `gt merge` ignores all three; we don't. One GraphQL call per PR.
 REPO_NWO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) || fail "no-repo" "could not resolve owner/repo"
 REPO_OWNER="${REPO_NWO%/*}"
 REPO_NAME="${REPO_NWO#*/}"
 UNRESOLVED_DETAIL=""
+BLOCKED_DETAIL=""
+TRUNCATED_DETAIL=""
 for pr in "${PR_LIST[@]}"; do
-    n=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewThreads(first:50){nodes{isResolved isOutdated}}}}}' \
+    GATE_JSON=$(gh api graphql -f query='query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviewDecision reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved isOutdated}}}}}' \
         -F o="$REPO_OWNER" -F r="$REPO_NAME" -F n="$pr" \
-        --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length' 2>/dev/null || echo "ERR")
-    [ "$n" = "ERR" ] && fail "graphql-error" "could not query review threads for PR #$pr"
+        --jq '{decision: .data.repository.pullRequest.reviewDecision, unresolved: ([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved==false and .isOutdated==false)] | length), truncated: .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage}' 2>/dev/null) \
+        || fail "graphql-error" "could not query review state for PR #$pr"
+    n=$(jq -r '.unresolved' <<<"$GATE_JSON")
+    decision=$(jq -r '.decision // ""' <<<"$GATE_JSON")
+    truncated=$(jq -r '.truncated' <<<"$GATE_JSON")
     [ "$n" -gt 0 ] && UNRESOLVED_DETAIL+="#${pr}:${n} "
+    [ "$decision" = "CHANGES_REQUESTED" ] && BLOCKED_DETAIL+="#${pr} "
+    [ "$truncated" = "true" ] && TRUNCATED_DETAIL+="#${pr} "
 done
 [ -z "$UNRESOLVED_DETAIL" ] || fail "unresolved-review-threads" "resolve threads before merging: ${UNRESOLVED_DETAIL}"
+[ -z "$BLOCKED_DETAIL" ]    || fail "changes-requested" "maintainer requested changes on: ${BLOCKED_DETAIL}"
+[ -z "$TRUNCATED_DETAIL" ]  || fail "review-threads-truncated" "PR has >100 threads (paginate via endCursor or treat as unsafe): ${TRUNCATED_DETAIL}"
 
 # 4. Kick off cascade (returns quickly; merge happens server-side)
 START_TIME=$(date +%s)


### PR DESCRIPTION
## Summary

- Reconcile two-way drift between the vendored `.claude/skills/graphite-pr/SKILL.md` and the runtime canonical at `~/.agents/skills/graphite-pr/SKILL.md`. Each had improvements the other lacked.
- Merged section "After submit: merge" now keeps:
  - Runtime side: `scripts/gt-merge-cascade.sh` for stacks; GraphQL pre-flight (`reviewThreads` + `reviewDecision`) for single-PR safety net before `gh pr merge`.
  - Vendored side: diagnostic for when the `Graphite / AI Reviews` check doesn't appear; bottom-up `gh pr merge` alternative; `--delete-branch` cascade-close warning + `--base $(gt trunk)` workaround; "record SHA before `gt sync --force`" tip.
- Quick-reference: split the "track an untracked branch" row into **first-time** (use literal trunk name — `gt trunk` errors when HEAD itself is untracked) and **existing-stack** (the original `$(gt trunk)` form). This came from a real failure during a Nazgûl run earlier today.
- Runtime canonical at `~/.agents/skills/graphite-pr/SKILL.md` mirrored to match — Claude continues to read it via the existing symlink at `~/.claude/skills/graphite-pr`; Codex picks it up via its `[[skills.config]]` entry.

## Test plan

- [ ] Open the file and skim the merged "After submit: merge" section reads coherently end-to-end (no leftover bullets from one side, no contradictions).
- [ ] `diff -q ~/.agents/skills/graphite-pr/SKILL.md .claude/skills/graphite-pr/SKILL.md` returns no output (sync verified locally; re-verify on merge).
- [ ] Markdown lint stays green per repo `.markdownlint.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciled the vendored `./.claude/skills/graphite-pr/SKILL.md` with the runtime canonical and hardened the merge flow with a vendored cascade script, stricter GraphQL gates, and clearer recovery guidance to prevent unsafe merges on large PRs. Also validated cascade script CLI args to preserve the JSON error contract.

- **Refactors**
  - Vendored `scripts/gt-merge-cascade.sh`; script now validates CLI poll/timeout as positive integers, validates the stack, blocks on unresolved threads, `CHANGES_REQUESTED`, and >100-thread truncation, maps branches→PRs safely (fails if any branch lacks an open PR), runs `gt merge`, polls to completion, and emits JSON.
  - Single-PR gate: GraphQL pre-flight uses `reviewThreads(first:100)` with `pageInfo.hasNextPage` → `truncated`; merge only when `unresolved == 0`, `decision != "CHANGES_REQUESTED"`, and `truncated == false`.
  - Docs: fixed broken troubleshooting link to `references/recovery.md`; kept the Graphite/AI Reviews diagnostic, bottom-up `gh pr merge` alternative, `--delete-branch` warning + `--base $(gt trunk)` workaround, SHA-before-sync tip; quick-reference splits first-time vs existing-stack `gt track`.

<sup>Written for commit 73b7002ce640c139c558f7dda6e115fffd203274. Summary will update on new commits. <a href="https://cubic.dev/pr/George-RD/claude-next-level/pull/65?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated merge-cascade: validates stack readiness, gates on unresolved review threads/decisions, performs merges, and reports per-PR timing and failures.
  * Added single-PR preflight to block merges when reviews are unresolved or changes are requested.

* **Documentation**
  * Simplified merge instructions, added a “Graphite merge queue” option, explicit recovery guidance, and clearer first-time vs existing-branch tracking steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->